### PR TITLE
Add pytest tests for utility functions

### DIFF
--- a/tests/test_dimensionality_parser.py
+++ b/tests/test_dimensionality_parser.py
@@ -1,0 +1,24 @@
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from dimensionality_parser import parse_slice
+
+
+def test_parse_slice_single_value():
+    assert parse_slice("5") == (5, 6, 1)
+
+
+def test_parse_slice_range():
+    assert parse_slice("1:4") == (1, 4, 1)
+
+
+def test_parse_slice_step():
+    assert parse_slice("2:8:2") == (2, 8, 2)
+
+
+def test_parse_slice_invalid():
+    with pytest.raises(ValueError):
+        parse_slice("1:2:3:4")

--- a/tests/test_maxproj_registration.py
+++ b/tests/test_maxproj_registration.py
@@ -1,0 +1,31 @@
+import sys
+import types
+from pathlib import Path
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Provide a stub pandas module so the import succeeds
+sys.modules.setdefault('pandas', types.ModuleType('pandas'))
+
+from maxproj_registration import zero_shift_multi_dimensional
+
+
+def test_zero_shift_positive_negative():
+    arr = np.arange(9).reshape(3, 3)
+    result = zero_shift_multi_dimensional(arr, shifts=(1, -1), fill_value=-1)
+    expected = np.array([
+        [-1, -1, -1],
+        [1, 2, -1],
+        [4, 5, -1],
+    ])
+    assert np.array_equal(result, expected)
+
+
+def test_zero_shift_errors():
+    arr = np.zeros((2, 2))
+    with pytest.raises(ValueError):
+        zero_shift_multi_dimensional(arr, shifts=(1,))
+    with pytest.raises(TypeError):
+        zero_shift_multi_dimensional(arr, shifts=(1.0, 2.0))

--- a/tests/test_visual_utils.py
+++ b/tests/test_visual_utils.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+matplotlib = pytest.importorskip("matplotlib")
+matplotlib.use("Agg")
+
+from matplotlib import colormaps as mpl_colormaps
+from matplotlib.figure import Figure
+from color_coded_projection import color_coded_projection
+from hist_imshow import hist_imshow
+
+
+def test_color_coded_projection_basic():
+    img = np.zeros((3, 2, 2), dtype=float)
+    img[1] = 1.0
+    result = color_coded_projection(img, color_map='plasma')
+    assert result.shape == (2, 2, 3)
+    expected_color = mpl_colormaps['plasma'](1 / (3 - 1))[:3]
+    expected = np.stack([np.full((2, 2), expected_color[c]) for c in range(3)], axis=-1)
+    assert np.allclose(result, expected)
+
+
+def test_color_coded_projection_invalid_input():
+    with pytest.raises(ValueError):
+        color_coded_projection(np.zeros((2, 2)))
+
+
+def test_hist_imshow_return_image_only():
+    img = np.random.rand(3, 4, 5)
+    slice_img = hist_imshow(img, return_image_only=True)
+    assert slice_img.shape == (4, 5)
+    assert np.allclose(slice_img, img[1])
+
+
+def test_hist_imshow_returns_figure():
+    fig = hist_imshow(np.random.rand(2, 2))
+    assert isinstance(fig, Figure)


### PR DESCRIPTION
## Summary
- add new tests covering parse_slice and image manipulation utilities
- ensure tests can import modules by adjusting `sys.path`

## Testing
- `python -m pip install .` *(fails: Could not fetch build dependencies)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687581d17b348331aa047ba256afa69e