### PR TITLE
Add image statistics to histogram label

### DIFF
--- a/hist_imshow.py
+++ b/hist_imshow.py
@@ -65,7 +65,14 @@ def hist_imshow(image, bins=64, gamma = 1, return_image_only = False,  **imshow_
     axes['Histogram'].hist((image.ravel()), bins=bins, density = True, histtype='stepfilled')
     axes['Histogram'].set_yscale('log')
     # axes['Histogram'].ticklabel_format(axis='y', style='scientific', scilimits=(0, 0))
-    axes['Histogram'].set_xlabel(f' Pixel intensity \n \n shape: {im_shape} \n dtype: {image.dtype}')
+
+    min_val = image.min()
+    max_val = image.max()
+    mean_val = image.mean()
+    stats_msg = f"min:{min_val:.3g} max:{max_val:.3g} mean:{mean_val:.3g}"
+    axes['Histogram'].set_xlabel(
+        f' Pixel intensity ({stats_msg}) \n \n shape: {im_shape} \n dtype: {image.dtype}'
+    )
     axes['Histogram'].set_ylabel('Log Frequency')
 
     # axes['Histogram'].set_xlim(0, 1)

--- a/tests/test_visual_utils.py
+++ b/tests/test_visual_utils.py
@@ -39,3 +39,11 @@ def test_hist_imshow_return_image_only():
 def test_hist_imshow_returns_figure():
     fig = hist_imshow(np.random.rand(2, 2))
     assert isinstance(fig, Figure)
+
+
+def test_hist_imshow_xlabel_contains_statistics():
+    img = np.array([[0, 1], [2, 3]], dtype=float)
+    fig = hist_imshow(img)
+    label = fig.axes[1].get_xlabel()
+    expected = f"min:{img.min():.3g} max:{img.max():.3g} mean:{img.mean():.3g}"
+    assert expected in label


### PR DESCRIPTION
## Summary
- compute min, max and mean of the displayed slice inside `hist_imshow`
- append these statistics to the histogram x-axis label
- test that the label includes the formatted statistics string

## Testing
- `pytest -q`
- `pip install -e .` *(fails: ProxyError - Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6876c61109208331a462bbb216a7b9b2