### PR TITLE
Return axes from hist_imshow

### DIFF
--- a/hist_imshow.py
+++ b/hist_imshow.py
@@ -6,28 +6,38 @@ def hist_imshow(image, bins=64, gamma = 1, return_image_only = False,  **imshow_
     """
     Displays an image and its histogram.
 
-    This function processes a given image stack, ensuring it is in a 2D format suitable for display. If the image
-    stack has more than two dimensions, the function extracts the middle slice from each of the extra dimensions, 
-    and then displays this 2D slice. Alongside the image, the function plots a histogram of the pixel 
-    intensities to provide a visual representation of the distribution of pixel values within the image.
+    This function processes a given image stack, ensuring it is in a 2D format suitable for display. If the
+    image stack has more than two dimensions, the function extracts the middle slice from each of the extra
+    dimensions and then displays this 2D slice. Alongside the image, the function plots a histogram of the
+    pixel intensities to provide a visual representation of the distribution of pixel values within the image.
 
-    Parameters:
-    image (array-like): The input image. Can be multidimensional, but only a 2D slice (from the middle of 
-                        any extra dimensions) will be displayed.
-    bins (int, optional): The number of bins to use for the histogram. Default is 256.
+    Parameters
+    ----------
+    image : array-like
+        The input image. Can be multidimensional, but only a 2D slice (from the middle of any extra
+        dimensions) will be displayed.
+    bins : int, optional
+        The number of bins to use for the histogram. Default is 256.
 
-    Returns:
-    matplotlib.figure.Figure: A figure object with two subplots - one showing the image and the other 
-                              showing its histogram.
+    Returns
+    -------
+    dict
+        A dictionary with two entries:
+        ``"fig"`` containing the created :class:`matplotlib.figure.Figure` and
+        ``"axes"`` containing a mapping of axis names to :class:`matplotlib.axes.Axes`
+        objects. When ``return_image_only`` is ``True`` this function returns only
+        the 2D image slice.
 
-    Note:
-    Additional information about the original shape and data type of the image is displayed on the x-axis 
-    label of the histogram.
+    Notes
+    -----
+    Additional information about the original shape and data type of the image is displayed on the x-axis label
+    of the histogram.
 
-    Example:
+    Examples
+    --------
     >>> img = np.random.rand(100, 100)  # Generate a random image
-    >>> fig = hist_imshow(img)
-    >>> plt.show()  # Display the figure with the image and its histogram
+    >>> res = hist_imshow(img)
+    >>> res["fig"].show()  # Display the figure with the image and its histogram
     """
 
     # Ensure 'origin' is set to 'lower' if not specified
@@ -72,4 +82,4 @@ def hist_imshow(image, bins=64, gamma = 1, return_image_only = False,  **imshow_
     # axes['Histogram'].set_yticks([])
 
 
-    return fig
+    return {"fig": fig, "axes": axes}

--- a/tests/test_visual_utils.py
+++ b/tests/test_visual_utils.py
@@ -10,6 +10,7 @@ matplotlib.use("Agg")
 
 from matplotlib import colormaps as mpl_colormaps
 from matplotlib.figure import Figure
+from matplotlib.axes import Axes
 from color_coded_projection import color_coded_projection
 from hist_imshow import hist_imshow
 
@@ -36,6 +37,20 @@ def test_hist_imshow_return_image_only():
     assert np.allclose(slice_img, img[1])
 
 
-def test_hist_imshow_returns_figure():
-    fig = hist_imshow(np.random.rand(2, 2))
+def test_hist_imshow_returns_dict_with_fig_and_axes():
+    res = hist_imshow(np.random.rand(2, 2))
+    assert isinstance(res, dict)
+    fig = res.get("fig")
+    axes = res.get("axes")
     assert isinstance(fig, Figure)
+    assert isinstance(axes, dict)
+    assert set(axes.keys()) == {"Image", "Histogram"}
+    for ax in axes.values():
+        assert isinstance(ax, Axes)
+
+
+def test_hist_imshow_axes_dict_contents():
+    res = hist_imshow(np.random.rand(5, 5))
+    axes = res["axes"]
+    assert list(axes.keys()) == ["Image", "Histogram"]
+    assert all(isinstance(ax, Axes) for ax in axes.values())


### PR DESCRIPTION
## Summary
- return dictionary containing figure and axes from `hist_imshow`
- update docstring for new return value
- expect returned dictionary in `test_visual_utils`

## Testing
- `pip install .` *(fails: could not fetch build dependencies)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876c6160b888331bd2855e6df2b6a85