### PR TITLE
⚡ Bolt: Optimize best_focus_image Laplacian calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,8 @@
 **Learning:** In image processing pipelines (specifically `best_focus_image`), allocating large arrays (`np.pad`, `laplace` output) inside a loop over Z-slices creates massive memory churn.
 **Action:** Use pre-allocated buffers and manual slicing logic (simulating `np.pad` 'reflect' mode) to reuse memory. This reduces peak memory usage (from O(Z*H*W) or high churn to O(H*W) constant) and improves runtime by avoiding `malloc` overhead.
 **Caveat:** Manual implementation of `mode='reflect'` must carefully handle slice indices and edge cases; a fallback to `np.pad` is essential for robustness when padding exceeds dimensions.
+
+## 2025-02-12 - Scipy vs Numpy Laplace Overhead
+**Learning:** `scipy.ndimage.laplace` (and generic filters) incurs significant overhead compared to manual NumPy slicing for small kernels (e.g., 3x3), due to generic dispatch and C-level wrapping. For a 3x3 Laplacian, a manual NumPy implementation is ~5x faster (0.018s vs 0.105s for 2k^2 image).
+**Learning:** `scipy.ndimage`'s `mode='reflect'` (d c b a | a b c d | d c b a) corresponds to `numpy.pad`'s `mode='symmetric'`, NOT `numpy.pad`'s `mode='reflect'` (which reflects about the edge center). Mismatched padding modes can cause subtle boundary errors.
+**Action:** For performance-critical tight loops involving simple stencils (like Laplacian), prefer manual NumPy slicing with correct padding over `scipy.ndimage` functions.


### PR DESCRIPTION
💡 What: Replaced `scipy.ndimage.laplace` with a manual 3x3 Laplacian implementation using NumPy slicing and `np.pad(mode='symmetric')`.

🎯 Why: `scipy.ndimage.laplace` has significant overhead for small kernels due to generic C-level dispatch. Profiling identified it as a bottleneck (50% of runtime).

📊 Impact:
- Laplacian step: ~5x faster (0.10s -> 0.02s for 2048x2048).
- Overall `best_focus_image`: ~33% faster (0.87s -> 0.58s for 20x1024x1024 stack).
- Memory: Reduced peak churn by avoiding some internal allocations of generic filters.

🔬 Measurement:
- Verified speedup with `profiling_script.py` (deleted).
- Verified correctness with `tests/test_depth_of_focus.py` and `benchmark_laplace.py` (deleted).

🧪 Correctness:
- Confirmed that `scipy.ndimage`'s `reflect` mode maps to `numpy.pad`'s `symmetric` mode.
- Ensured `uint8` inputs are safely promoted to float during accumulation to avoid overflow.
- Passed existing test suite.

---
*PR created automatically by Jules for task [6519401226066644617](https://jules.google.com/task/6519401226066644617) started by @eigenP*