### PR TITLE
fix: add fallback to explicitly download cells3d in wasm environments

### DIFF
--- a/marimo_app.py
+++ b/marimo_app.py
@@ -9,7 +9,14 @@
         from skimage.data import cells3d
         from eigenp_utils.tnia_plotting_anywidgets import show_xyz_max_slice_interactive
 
-        im = cells3d()  # (Z, C, Y, X)
+        try:
+        im = cells3d()
+    except:
+        from eigenp_utils.io import download_file
+        url_to_fetch = "https://gitlab.com/scikit-image/data/-/raw/master/cells3d.tif"
+        download_file(url_to_fetch, "./cells3d.tif")
+        from skimage.io import imread
+        im = imread("./cells3d.tif")  # (Z, C, Y, X)
         membrane = im[:, 0, :, :]
         nuclei = im[:, 1, :, :]
 

--- a/marimo_app.py
+++ b/marimo_app.py
@@ -10,20 +10,20 @@
         from eigenp_utils.tnia_plotting_anywidgets import show_xyz_max_slice_interactive
 
         try:
-        im = cells3d()
-    except:
-        from eigenp_utils.io import download_file
-        url_to_fetch = "https://gitlab.com/scikit-image/data/-/raw/master/cells3d.tif"
-        download_file(url_to_fetch, "./cells3d.tif")
-        from skimage.io import imread
-        im = imread("./cells3d.tif")  # (Z, C, Y, X)
-        membrane = im[:, 0, :, :]
-        nuclei = im[:, 1, :, :]
-
+            im = cells3d()
+        except:
+            from eigenp_utils.io import download_file
+            url_to_fetch = "https://gitlab.com/scikit-image/data/-/raw/master/cells3d.tif"
+            download_file(url_to_fetch, "./cells3d.tif")
+            from skimage.io import imread
+            im = imread("./cells3d.tif")  # (Z, C, Y, X)
+            membrane = im[:, 0, :, :]
+            nuclei = im[:, 1, :, :]
+    
         widget = show_xyz_max_slice_interactive(
-            [membrane, nuclei],
-            colors=['magma', 'viridis']
-        )
+                [membrane, nuclei],
+                colors=['magma', 'viridis']
+            )
         return widget,
 
     if __name__ == "__main__":

--- a/notebooks/demo_multichannel_interactive_ortho_views.py
+++ b/notebooks/demo_multichannel_interactive_ortho_views.py
@@ -111,7 +111,28 @@ def _():
     )
 
     # Load the 3D cell data (Z, C, Y, X)
-    cells = cells3d()
+    try:
+        try:
+        try:
+            cells = cells3d()
+        except:
+            from eigenp_utils.io import download_file
+            url_to_fetch = "https://gitlab.com/scikit-image/data/-/raw/master/cells3d.tif"
+            download_file(url_to_fetch, "./cells3d.tif")
+            from skimage.io import imread
+            cells = imread("./cells3d.tif")
+    except:
+        from eigenp_utils.io import download_file
+        url_to_fetch = "https://gitlab.com/scikit-image/data/-/raw/master/cells3d.tif"
+        download_file(url_to_fetch, "./cells3d.tif")
+        from skimage.io import imread
+        cells = imread("./cells3d.tif")
+    except:
+        from eigenp_utils.io import download_file
+        url_to_fetch = "https://gitlab.com/scikit-image/data/-/raw/master/cells3d.tif"
+        download_file(url_to_fetch, "./cells3d.tif")
+        from skimage.io import imread
+        cells = imread("./cells3d.tif")
     print(f"Loaded cells3d with shape: {cells.shape}")
 
     # Extract channels and cast to float to prevent clipping/overflow issues in blending

--- a/notebooks/demo_multichannel_interactive_ortho_views.py
+++ b/notebooks/demo_multichannel_interactive_ortho_views.py
@@ -112,27 +112,14 @@ def _():
 
     # Load the 3D cell data (Z, C, Y, X)
     try:
-        try:
-        try:
-            cells = cells3d()
-        except:
-            from eigenp_utils.io import download_file
-            url_to_fetch = "https://gitlab.com/scikit-image/data/-/raw/master/cells3d.tif"
-            download_file(url_to_fetch, "./cells3d.tif")
-            from skimage.io import imread
-            cells = imread("./cells3d.tif")
+        cells = cells3d()
     except:
         from eigenp_utils.io import download_file
         url_to_fetch = "https://gitlab.com/scikit-image/data/-/raw/master/cells3d.tif"
         download_file(url_to_fetch, "./cells3d.tif")
         from skimage.io import imread
         cells = imread("./cells3d.tif")
-    except:
-        from eigenp_utils.io import download_file
-        url_to_fetch = "https://gitlab.com/scikit-image/data/-/raw/master/cells3d.tif"
-        download_file(url_to_fetch, "./cells3d.tif")
-        from skimage.io import imread
-        cells = imread("./cells3d.tif")
+
     print(f"Loaded cells3d with shape: {cells.shape}")
 
     # Extract channels and cast to float to prevent clipping/overflow issues in blending

--- a/tests/marimo_app.py
+++ b/tests/marimo_app.py
@@ -9,7 +9,14 @@ def __():
     from skimage.data import cells3d
     from eigenp_utils.tnia_plotting_anywidgets import show_xyz_max_slice_interactive
 
-    im = cells3d()  # (Z, C, Y, X)
+    try:
+        im = cells3d()
+    except:
+        from eigenp_utils.io import download_file
+        url_to_fetch = "https://gitlab.com/scikit-image/data/-/raw/master/cells3d.tif"
+        download_file(url_to_fetch, "./cells3d.tif")
+        from skimage.io import imread
+        im = imread("./cells3d.tif")  # (Z, C, Y, X)
     membrane = im[:, 0, :, :]
     nuclei = im[:, 1, :, :]
 

--- a/tests/test_marimo_update.py
+++ b/tests/test_marimo_update.py
@@ -13,7 +13,14 @@ def test_marimo_update():
         from skimage.data import cells3d
         from eigenp_utils.tnia_plotting_anywidgets import show_xyz_max_slice_interactive
 
-        im = cells3d()  # (Z, C, Y, X)
+        try:
+        im = cells3d()
+    except:
+        from eigenp_utils.io import download_file
+        url_to_fetch = "https://gitlab.com/scikit-image/data/-/raw/master/cells3d.tif"
+        download_file(url_to_fetch, "./cells3d.tif")
+        from skimage.io import imread
+        im = imread("./cells3d.tif")  # (Z, C, Y, X)
         membrane = im[:, 0, :, :]
         nuclei = im[:, 1, :, :]
 

--- a/tests/test_marimo_update.py
+++ b/tests/test_marimo_update.py
@@ -14,13 +14,13 @@ def test_marimo_update():
         from eigenp_utils.tnia_plotting_anywidgets import show_xyz_max_slice_interactive
 
         try:
-        im = cells3d()
-    except:
-        from eigenp_utils.io import download_file
-        url_to_fetch = "https://gitlab.com/scikit-image/data/-/raw/master/cells3d.tif"
-        download_file(url_to_fetch, "./cells3d.tif")
-        from skimage.io import imread
-        im = imread("./cells3d.tif")  # (Z, C, Y, X)
+            im = cells3d()
+        except:
+            from eigenp_utils.io import download_file
+            url_to_fetch = "https://gitlab.com/scikit-image/data/-/raw/master/cells3d.tif"
+            download_file(url_to_fetch, "./cells3d.tif")
+            from skimage.io import imread
+            im = imread("./cells3d.tif")  # (Z, C, Y, X)
         membrane = im[:, 0, :, :]
         nuclei = im[:, 1, :, :]
 


### PR DESCRIPTION
The user wanted to investigate whether `eigenp-utils` and its interactive 3D widgets could be installed via `micropip` in Pyodide.

After successfully demonstrating that Pyodide is fully capable of installing `scikit-image` and resolving dependencies via the `pyodide-build` environment, we observed that network fetches using the `skimage.data` functions (such as `cells3d()`) often fail in WASM environments.

Instead of hiding or removing `skimage` imports (as it's fully compatible in WASM), this PR addresses the root issue by adding a robust fallback to download `cells3d.tif` explicitly using `eigenp_utils.io.download_file` in testing scripts, `marimo` app templates, and interactive notebook tutorials whenever the standard `skimage.data.cells3d()` fails.

---
*PR created automatically by Jules for task [1012398052613539810](https://jules.google.com/task/1012398052613539810) started by @eigenP*