### PR TITLE
Fix TraitError caused by NaN on cleared numeric inputs in AnyWidgets

### DIFF
--- a/src/eigenp_utils/tnia_plotting_anywidgets.js
+++ b/src/eigenp_utils/tnia_plotting_anywidgets.js
@@ -90,6 +90,11 @@ export default {
         // Inverse scale to get integer index
         let newIndex = Math.round(parseFloat(numberInput.value) / scale);
 
+        if (isNaN(newIndex)) {
+            update();
+            return;
+        }
+
         // Clamp
         if (newIndex < min) newIndex = min;
         if (newIndex > max) newIndex = max;


### PR DESCRIPTION
Fixes a `TraitError` in `TNIASliceWidget` that occurs when a frontend number input field is cleared.

**Root cause:**
When a user clears a number input in the AnyWidget UI, `parseFloat(numberInput.value)` returns `NaN`. Sending `NaN` to the Python backend via `model.set()` serializes it as `null` in JSON. Because `y_t` (and similar traits) are strictly defined as `traitlets.Int(1)`, receiving `None` causes a `TraitError: The 'y_t' trait of a TNIASliceWidget instance expected an int, not the NoneType None`.

**Fix:**
Added a guard in `src/eigenp_utils/tnia_plotting_anywidgets.js`'s `createSlider` function. When `isNaN(newIndex)` evaluates to true, the code calls `update()` to revert the UI back to the current safe model state and returns early, preventing the invalid payload from being sent.

---
*PR created automatically by Jules for task [16664564489854715196](https://jules.google.com/task/16664564489854715196) started by @eigenP*