### PR TITLE
Fix histogram alignment in tnia_plotting_anywidgets

### DIFF
--- a/src/eigenp_utils/tnia_plotting_anywidgets.js
+++ b/src/eigenp_utils/tnia_plotting_anywidgets.js
@@ -335,7 +335,7 @@ export default {
         const histCanvas = document.createElement("canvas");
         histCanvas.width = 160;
         histCanvas.height = 30;
-        histCanvas.style.marginLeft = "auto";
+        histCanvas.style.marginLeft = "10px";
         histCanvas.style.border = "1px solid #ccc";
         histCanvas.style.borderRadius = "2px";
         histCanvas.style.backgroundColor = "#fff";


### PR DESCRIPTION
The histogram in the interactive viewer channel widgets is no longer right-justified via `marginLeft="auto"`. Instead, it has a simple 10px left margin so it naturally follows the opacity input slider.

---
*PR created automatically by Jules for task [2980991221386481364](https://jules.google.com/task/2980991221386481364) started by @eigenP*