### PR TITLE
⚡ matth: Exact Non-Negative Least Squares for LLE Barycenter

### DIFF
--- a/.jules/matth.md
+++ b/.jules/matth.md
@@ -1,0 +1,5 @@
+## 2024-05-24 - Exact Non-Negative Least Squares for LLE Barycenter
+
+**Learning:** When computing Locally Linear Embedding (LLE) weights, solving the unconstrained system `G_reg * w = 1` and then heuristically clipping negative weights to zero (`w = np.maximum(w, 0)`) is mathematically unsound. It does not actually solve the constrained optimization problem and can lead to suboptimal or invalid weights, especially when the regularized Gram matrix `G_reg` has a condition number indicating strong collinearity among neighbors. The exact solution to `min_w ||w||_G_reg^2` subject to `w >= 0` and `sum(w) = 1` can be obtained by solving the NNLS problem `min_w ||L^T w - z||^2` where `L` is the Cholesky factor of `G_reg` (`G_reg = L L^T`) and `z` solves `L z = 1`. The weights are then normalized to sum to one.
+
+**Action:** Replace the heuristic clipping with an exact NNLS dual formulation using Cholesky decomposition of the regularized Gram matrix in `src/eigenp_utils/single_cell.py:kknn_ingest` for computing LLE barycenter weights. This ensures mathematical correctness and robustness when projecting points onto the local manifold spanned by their nearest neighbors.

--- a/src/eigenp_utils/single_cell.py
+++ b/src/eigenp_utils/single_cell.py
@@ -11,6 +11,8 @@ from sklearn.neighbors import NearestNeighbors
 import anndata
 import scipy.sparse as sp
 from scipy.cluster import hierarchy
+import scipy.linalg
+import scipy.optimize
 from scipy.linalg import svd
 from scipy.stats import norm
 import matplotlib.pyplot as plt
@@ -4673,18 +4675,20 @@ def kknn_ingest(
                         reg = lle_reg_lambda
                     G_reg = G + reg * np.eye(len(idx))
 
-                    # Solve G * w = 1
+                    # Solve G * w = 1 with non-negativity constraint
                     try:
-                        w = np.linalg.solve(G_reg, np.ones(len(idx)))
-                        # Enforce non-negativity constraint
-                        w = np.maximum(w, 0)
+                        # Exact NNLS using Cholesky decomposition of G_reg
+                        L = scipy.linalg.cholesky(G_reg, lower=True)
+                        z = scipy.linalg.solve_triangular(L, np.ones(len(idx)), lower=True)
+                        w, _ = scipy.optimize.nnls(L.T, z)
+
                         w_sum = np.sum(w)
                         if w_sum > 0:
                             weights = w / w_sum
                         else:
                             # Fallback to uniform if all weights became zero
                             weights = np.ones(len(idx)) / len(idx)
-                    except np.linalg.LinAlgError:
+                    except (np.linalg.LinAlgError, scipy.linalg.LinAlgError):
                         # Fallback to inverse distance if singular
                         weights = 1.0 / (dist + 1e-8)
                         weights /= np.sum(weights)


### PR DESCRIPTION
Replaced mathematically unsound heuristic clipping of weights with an exact Non-Negative Least Squares (NNLS) solver using the Cholesky decomposition of the regularized Gram matrix in the Locally Linear Embedding (LLE) barycenter calculation.

---
*PR created automatically by Jules for task [3812924823985911145](https://jules.google.com/task/3812924823985911145) started by @eigenP*