### PR TITLE
Fix scale bars logic in interactive viewers

### DIFF
--- a/src/eigenp_utils/tnia_plotting_anywidgets.py
+++ b/src/eigenp_utils/tnia_plotting_anywidgets.py
@@ -292,15 +292,23 @@ def show_zyx(xy, xz, zy, pixel_sizes=None, sxy=None, sz=None, figsize=(10,10), c
     # fig.subplots_adjust(left=0.02, right=0.98, top=0.98, bottom=0.02)
 
     # Add scale bar
-    width_um = xdim * sxy
-    target = width_um * 0.2
+    ax3_physical_width_um = zdim * sz
+    _add_scale_bar(ax3, ax3_physical_width_um, both_given, figsize)
 
+    return fig
+
+
+
+def _add_scale_bar(ax, ax_physical_width_um, pixel_sizes_given, figsize):
     # a small utility to pick the largest “nice” number ≤ target
+    target = ax_physical_width_um * 0.2
+
     def nice_length(x):
         # get exponent
+        if x <= 0: return 1
         exp = np.floor(np.log10(x))
         # candidates: 1, 2, 5 times 10^exp
-        for m in [5,2,1]:
+        for m in [5, 2, 1]:
             val = m * 10**exp
             if val <= x:
                 return val
@@ -308,38 +316,29 @@ def show_zyx(xy, xz, zy, pixel_sizes=None, sxy=None, sz=None, figsize=(10,10), c
         return x
 
     bar_um = nice_length(target)
+    # Convert back to fraction of the full width of the current axes
+    bar_frac = bar_um / ax_physical_width_um if ax_physical_width_um > 0 else 0
 
-    # Convert back to pixels
-    bar_pix = bar_um / sxy
-    bar_frac = bar_pix / xdim    # fraction of the full width
-
-    # pick fontsize
+    # pick fontsize and line width to scale with figure size
     fig_h_in = figsize[1] if figsize is not None else 10
     fontsize_pt = max(8, min(24, fig_h_in * 72 * 0.03))
+    linewidth = max(1, fig_h_in * 0.2)
 
     ### Draw
-    # center the bar at (x=0.5), y=0.5 in ax3’s normalized coordinates:
-    x0 = 0.5 - bar_frac/2
-    x1 = 0.5 + bar_frac/2
-    y  = 0.5
+    # center the bar at (x=0.5), y=0.5 in ax's normalized coordinates:
+    x0 = 0.5 - bar_frac / 2
+    x1 = 0.5 + bar_frac / 2
+    y = 0.5
 
-    ax3.hlines(y, x0, x1, transform=ax3.transAxes,
-               linewidth=2, color='gray')
+    ax.hlines(y, x0, x1, transform=ax.transAxes, linewidth=linewidth, color='gray')
 
-    if both_given:
-        text_label = f"{int(bar_um)} µm"
+    if pixel_sizes_given:
+        text_label = f"{int(bar_um)} µm" if bar_um >= 1 else f"{bar_um:.2g} µm"
     else:
         text_label = "`pixel_sizes`"
 
-    ax3.text(0.5, y - 0.1, text_label,
-             transform=ax3.transAxes,
-             ha='center', va='top',
-             color='gray',
-             fontsize=fontsize_pt)
-
-    return fig
-
-
+    ax.text(0.5, y - 0.1, text_label, transform=ax.transAxes,
+            ha='center', va='top', color='gray', fontsize=fontsize_pt)
 
 ### New function
 def show_zyx_max_slabs(image_to_show, x=[0,1], y=[0,1], z=[0,1], pixel_sizes=None, sxy=None, sz=None, figsize=(10,10), colormap=None, vmin=None, vmax=None, gamma=1, colors=None, opacity=None):
@@ -1646,6 +1645,7 @@ class TNIAScatterWidget(TNIAWidgetBase):
         self.channels = channels
         self._sxy_given = sxy is not None
         self._sz_given = sz is not None
+        self._pixel_sizes_given = pixel_sizes is not None or (sxy is not None and sz is not None)
         pz, py, px = _parse_zyx_tuple_or_dict(pixel_sizes, default_val=1.0)
         self.sx = px
         self.sy = py
@@ -2055,30 +2055,10 @@ class TNIAScatterWidget(TNIAWidgetBase):
 
             # Scale bar (kept opaque)
             fig.patch.set_alpha(1.0)
-            width_um = (self.xmax - self.xmin + 1) * self.sx
-            target = width_um * 0.2
-            def nice_length(x):
-                exp = np.floor(np.log10(x))
-                for m in [5,2,1]:
-                    val = m * 10**exp
-                    if val <= x: return val
-                return x
-            bar_um = nice_length(target)
-            bar_pix = bar_um / self.sx
-            bar_frac = bar_pix / (self.xmax - self.xmin + 1)
-            fig_h_in = self.figsize[1] if self.figsize else 10
-            fontsize_pt = max(8, min(24, fig_h_in * 72 * 0.03))
-            x0 = 0.5 - bar_frac/2; x1 = 0.5 + bar_frac/2; y = 0.5
-            axBar.hlines(y, x0, x1, transform=axBar.transAxes, linewidth=2, color='gray')
-
+            Z_dim = int(np.ceil(self.zmax - self.zmin + 1))
+            ax3_physical_width_um = Z_dim * self.sz
             both_given = getattr(self, '_pixel_sizes_given', False)
-            if both_given:
-                text_label = f"{int(bar_um)} µm"
-            else:
-                text_label = "`pixel_sizes`"
-
-            axBar.text(0.5, y - 0.1, text_label, transform=axBar.transAxes,
-                       ha='center', va='top', color='gray', fontsize=fontsize_pt)
+            _add_scale_bar(axBar, ax3_physical_width_um, both_given, self.figsize)
 
             fig.tight_layout(pad=0.0)
             return fig
@@ -2152,6 +2132,8 @@ def show_zyx_max_slice_interactive(
         divisor = max(width_px / 8, height_px / 8)
         w, h = float(width_px / divisor), float(height_px / divisor)
         figsize = (w * figsize_scale, h * figsize_scale)
+    elif figsize_scale != 1.0:
+        figsize = (figsize[0] * figsize_scale, figsize[1] * figsize_scale)
 
     def _default_t(n): return max(1, n // 64)
     if x_t is None: x_t = _default_t(X)
@@ -2244,6 +2226,8 @@ def show_zyx_max_slice_interactive_point_annotator(
         divisor = max(width_px / 8, height_px / 8)
         w, h = float(width_px / divisor), float(height_px / divisor)
         figsize = (w * figsize_scale, h * figsize_scale)
+    elif figsize_scale != 1.0:
+        figsize = (figsize[0] * figsize_scale, figsize[1] * figsize_scale)
 
     def _default_t(n): return max(1, n // 64)
     if x_t is None: x_t = _default_t(X)
@@ -2374,6 +2358,8 @@ def show_zyx_max_scatter_interactive(
         divisor = max(width_px / 8, height_px / 8)
         w, h = float(width_px / divisor), float(height_px / divisor)
         figsize = (w * figsize_scale, h * figsize_scale)
+    elif figsize_scale != 1.0:
+        figsize = (figsize[0] * figsize_scale, figsize[1] * figsize_scale)
 
     def _default_t(n): return max(1, int(n // 64))
     Xdim = int(np.ceil(XN)); Ydim = int(np.ceil(YN)); Zdim = int(np.ceil(ZN))

--- a/tests/test_tnia_plotting_anywidgets.py
+++ b/tests/test_tnia_plotting_anywidgets.py
@@ -205,3 +205,56 @@ def test_deprecation_warnings_interactive(factory_fn):
         factory_fn(im, x_s=5, y_s=10, z_s=5)
     with pytest.warns(DeprecationWarning, match="The 'x_t', 'y_t', 'z_t' parameters are deprecated"):
         factory_fn(im, x_t=2, y_t=3, z_t=4)
+
+@pytest.mark.parametrize("shape, pixel_sizes, expected_text", [
+    ((100, 200, 300), (1, 2, 3), '20 µm'),
+    ((10, 50, 50), (0.5, 0.5, 0.5), '1 µm'),
+    ((1, 5, 5), (10, 10, 10), '2 µm'),
+    ((50, 100, 150), (2, 2, 2), '20 µm')
+])
+def test_scale_bar_logic(shape, pixel_sizes, expected_text):
+    from eigenp_utils.tnia_plotting_anywidgets import show_zyx_max_slice_interactive, show_zyx_max_scatter_interactive
+    import numpy as np
+
+    # Test slice interactive
+    im = np.zeros(shape)
+    w_slice = show_zyx_max_slice_interactive(im, pixel_sizes=pixel_sizes, figsize=(5,5))
+    fig_slice = w_slice._render()
+
+    # Extract text from scale bar
+    texts_slice = [txt.get_text() for ax in fig_slice.axes for txt in ax.texts]
+    assert expected_text in texts_slice
+
+    # Extract fontsize of the scale bar
+    font_size_unscaled = None
+    for ax in fig_slice.axes:
+        for txt in ax.texts:
+            if expected_text in txt.get_text():
+                font_size_unscaled = txt.get_fontsize()
+
+    # Test scatter interactive
+    Z, Y, X = shape
+    # Make points such that Z_dim=Z, Y_dim=Y, X_dim=X
+    points = (np.array([0, Z-1]), np.array([0, Y-1]), np.array([0, X-1]))
+    w_scatter = show_zyx_max_scatter_interactive(points, pixel_sizes=pixel_sizes, figsize=(5,5))
+    fig_scatter = w_scatter._render()
+
+    texts_scatter = [txt.get_text() for ax in fig_scatter.axes for txt in ax.texts]
+    assert expected_text in texts_scatter
+
+    # Test with figsize_scale to make sure it scales font and lines correctly
+    w_slice_scaled = show_zyx_max_slice_interactive(im, pixel_sizes=pixel_sizes, figsize=(5,5), figsize_scale=2.0)
+    fig_slice_scaled = w_slice_scaled._render()
+
+    font_size_scaled = None
+    linewidth_scaled = None
+    for ax in fig_slice_scaled.axes:
+        for txt in ax.texts:
+            if expected_text in txt.get_text():
+                font_size_scaled = txt.get_fontsize()
+        for collection in ax.collections:
+            if collection.get_linewidth():
+                linewidth_scaled = collection.get_linewidth()[0]
+
+    assert font_size_scaled is not None
+    assert font_size_scaled > font_size_unscaled


### PR DESCRIPTION
- Created `_add_scale_bar` helper in `tnia_plotting_anywidgets.py` to calculate target widths relative to the actual axes dimensions (`ax3_physical_width_um`), fixing cases where Z-axis dimensions affected X-axis scale bar representation.
- Corrected `figsize_scale` parameter logic in plotting wrappers to appropriately scale user-provided `figsize` and visually scale both `fontsize` and `linewidth` of the scale bar.
- Repaired `_pixel_sizes_given` attribute initialization bug in `TNIAScatterWidget`.
- Added parameterized unit tests in `test_tnia_plotting_anywidgets.py` verifying interactive widget scale bar parity across inputs.

---
*PR created automatically by Jules for task [8036267603807136588](https://jules.google.com/task/8036267603807136588) started by @eigenP*