### PR TITLE
Fix interactive scale bar rendering and responsive scaling logic

### DIFF
--- a/src/eigenp_utils/tnia_plotting_anywidgets.py
+++ b/src/eigenp_utils/tnia_plotting_anywidgets.py
@@ -80,6 +80,41 @@ def _norm(arr, symmetric=False, eps=1e-12, dtype=np.float32):
 
 
 # Copyright tnia 2021 - BSD License
+
+
+def _add_scale_bar(ax, ax_physical_width_um, pixel_sizes_given, figsize):
+    target = ax_physical_width_um * 0.2
+
+    def nice_length(x):
+        if x <= 0: return 1
+        exp = np.floor(np.log10(x))
+        for m in [5, 2, 1]:
+            val = m * 10**exp
+            if val <= x:
+                return val
+        return x
+
+    bar_um = nice_length(target)
+    bar_frac = bar_um / ax_physical_width_um if ax_physical_width_um > 0 else 0
+
+    fig_h_in = figsize[1] if figsize is not None else 10
+    fontsize_pt = max(8, min(24, fig_h_in * 72 * 0.03))
+    linewidth = max(1, fig_h_in * 0.2)
+
+    x0 = 0.5 - bar_frac / 2
+    x1 = 0.5 + bar_frac / 2
+    y = 0.5
+
+    ax.hlines(y, x0, x1, transform=ax.transAxes, linewidth=linewidth, color='gray')
+
+    if pixel_sizes_given:
+        text_label = f"{int(bar_um)} µm" if bar_um >= 1 else f"{bar_um:.2g} µm"
+    else:
+        text_label = "`pixel_sizes`"
+
+    ax.text(0.5, y - 0.1, text_label, transform=ax.transAxes,
+            ha='center', va='top', color='gray', fontsize=fontsize_pt)
+
 def show_zyx_slice(image_to_show, x, y, z, pixel_sizes=None, sxy=None, sz=None,figsize=(10,10), colormap=None, vmin = None, vmax=None, gamma = 1, use_plt=True, opacity=None):
     """ extracts xy, xz, and zy slices at x, y, z of a 3D image and plots them
 
@@ -292,50 +327,8 @@ def show_zyx(xy, xz, zy, pixel_sizes=None, sxy=None, sz=None, figsize=(10,10), c
     # fig.subplots_adjust(left=0.02, right=0.98, top=0.98, bottom=0.02)
 
     # Add scale bar
-    width_um = xdim * sxy
-    target = width_um * 0.2
-
-    # a small utility to pick the largest “nice” number ≤ target
-    def nice_length(x):
-        # get exponent
-        exp = np.floor(np.log10(x))
-        # candidates: 1, 2, 5 times 10^exp
-        for m in [5,2,1]:
-            val = m * 10**exp
-            if val <= x:
-                return val
-        # if nothing smaller (very small x), just return x itself
-        return x
-
-    bar_um = nice_length(target)
-
-    # Convert back to pixels
-    bar_pix = bar_um / sxy
-    bar_frac = bar_pix / xdim    # fraction of the full width
-
-    # pick fontsize
-    fig_h_in = figsize[1] if figsize is not None else 10
-    fontsize_pt = max(8, min(24, fig_h_in * 72 * 0.03))
-
-    ### Draw
-    # center the bar at (x=0.5), y=0.5 in ax3’s normalized coordinates:
-    x0 = 0.5 - bar_frac/2
-    x1 = 0.5 + bar_frac/2
-    y  = 0.5
-
-    ax3.hlines(y, x0, x1, transform=ax3.transAxes,
-               linewidth=2, color='gray')
-
-    if both_given:
-        text_label = f"{int(bar_um)} µm"
-    else:
-        text_label = "`pixel_sizes`"
-
-    ax3.text(0.5, y - 0.1, text_label,
-             transform=ax3.transAxes,
-             ha='center', va='top',
-             color='gray',
-             fontsize=fontsize_pt)
+    ax3_physical_width_um = zdim * sz
+    _add_scale_bar(ax3, ax3_physical_width_um, both_given, figsize)
 
     return fig
 
@@ -1646,6 +1639,7 @@ class TNIAScatterWidget(TNIAWidgetBase):
         self.channels = channels
         self._sxy_given = sxy is not None
         self._sz_given = sz is not None
+        self._pixel_sizes_given = pixel_sizes is not None
         pz, py, px = _parse_zyx_tuple_or_dict(pixel_sizes, default_val=1.0)
         self.sx = px
         self.sy = py
@@ -2055,30 +2049,10 @@ class TNIAScatterWidget(TNIAWidgetBase):
 
             # Scale bar (kept opaque)
             fig.patch.set_alpha(1.0)
-            width_um = (self.xmax - self.xmin + 1) * self.sx
-            target = width_um * 0.2
-            def nice_length(x):
-                exp = np.floor(np.log10(x))
-                for m in [5,2,1]:
-                    val = m * 10**exp
-                    if val <= x: return val
-                return x
-            bar_um = nice_length(target)
-            bar_pix = bar_um / self.sx
-            bar_frac = bar_pix / (self.xmax - self.xmin + 1)
-            fig_h_in = self.figsize[1] if self.figsize else 10
-            fontsize_pt = max(8, min(24, fig_h_in * 72 * 0.03))
-            x0 = 0.5 - bar_frac/2; x1 = 0.5 + bar_frac/2; y = 0.5
-            axBar.hlines(y, x0, x1, transform=axBar.transAxes, linewidth=2, color='gray')
-
+            Z_dim = int(np.ceil(self.zmax - self.zmin + 1))
+            ax3_physical_width_um = Z_dim * self.sz
             both_given = getattr(self, '_pixel_sizes_given', False)
-            if both_given:
-                text_label = f"{int(bar_um)} µm"
-            else:
-                text_label = "`pixel_sizes`"
-
-            axBar.text(0.5, y - 0.1, text_label, transform=axBar.transAxes,
-                       ha='center', va='top', color='gray', fontsize=fontsize_pt)
+            _add_scale_bar(axBar, ax3_physical_width_um, both_given, self.figsize)
 
             fig.tight_layout(pad=0.0)
             return fig
@@ -2152,6 +2126,8 @@ def show_zyx_max_slice_interactive(
         divisor = max(width_px / 8, height_px / 8)
         w, h = float(width_px / divisor), float(height_px / divisor)
         figsize = (w * figsize_scale, h * figsize_scale)
+    elif figsize_scale != 1.0:
+        figsize = (figsize[0] * figsize_scale, figsize[1] * figsize_scale)
 
     def _default_t(n): return max(1, n // 64)
     if x_t is None: x_t = _default_t(X)
@@ -2244,6 +2220,8 @@ def show_zyx_max_slice_interactive_point_annotator(
         divisor = max(width_px / 8, height_px / 8)
         w, h = float(width_px / divisor), float(height_px / divisor)
         figsize = (w * figsize_scale, h * figsize_scale)
+    elif figsize_scale != 1.0:
+        figsize = (figsize[0] * figsize_scale, figsize[1] * figsize_scale)
 
     def _default_t(n): return max(1, n // 64)
     if x_t is None: x_t = _default_t(X)
@@ -2374,6 +2352,8 @@ def show_zyx_max_scatter_interactive(
         divisor = max(width_px / 8, height_px / 8)
         w, h = float(width_px / divisor), float(height_px / divisor)
         figsize = (w * figsize_scale, h * figsize_scale)
+    elif figsize_scale != 1.0:
+        figsize = (figsize[0] * figsize_scale, figsize[1] * figsize_scale)
 
     def _default_t(n): return max(1, int(n // 64))
     Xdim = int(np.ceil(XN)); Ydim = int(np.ceil(YN)); Zdim = int(np.ceil(ZN))

--- a/tests/test_tnia_plotting_anywidgets.py
+++ b/tests/test_tnia_plotting_anywidgets.py
@@ -205,3 +205,74 @@ def test_deprecation_warnings_interactive(factory_fn):
         factory_fn(im, x_s=5, y_s=10, z_s=5)
     with pytest.warns(DeprecationWarning, match="The 'x_t', 'y_t', 'z_t' parameters are deprecated"):
         factory_fn(im, x_t=2, y_t=3, z_t=4)
+
+def test_scale_bar_logic():
+    from eigenp_utils.tnia_plotting_anywidgets import show_zyx_max_slice_interactive, show_zyx_max_scatter_interactive
+    import numpy as np
+
+    # Test slice interactive
+    im = np.zeros((100, 200, 300))
+    w_slice = show_zyx_max_slice_interactive(im, pixel_sizes=(1, 2, 3), figsize=(5,5))
+    fig_slice = w_slice._render()
+
+    # Extract text from scale bar
+    texts_slice = [txt.get_text() for ax in fig_slice.axes for txt in ax.texts]
+    assert '20 µm' in texts_slice
+
+    # Extract fontsize of the scale bar
+    font_size_unscaled = None
+    for ax in fig_slice.axes:
+        for txt in ax.texts:
+            if '20 µm' in txt.get_text():
+                font_size_unscaled = txt.get_fontsize()
+
+    # Test scatter interactive
+    # Make points such that Z_dim=100, Y_dim=200, X_dim=300
+    points = (np.array([0, 99]), np.array([0, 199]), np.array([0, 299]))
+    w_scatter = show_zyx_max_scatter_interactive(points, pixel_sizes=(1, 2, 3), figsize=(5,5))
+    fig_scatter = w_scatter._render()
+
+    texts_scatter = [txt.get_text() for ax in fig_scatter.axes for txt in ax.texts]
+    assert '20 µm' in texts_scatter
+
+    # Test with figsize_scale to make sure it scales font and lines correctly
+    w_slice_scaled = show_zyx_max_slice_interactive(im, pixel_sizes=(1, 2, 3), figsize=(5,5), figsize_scale=2.0)
+    fig_slice_scaled = w_slice_scaled._render()
+
+    font_size_scaled = None
+    linewidth_scaled = None
+    for ax in fig_slice_scaled.axes:
+        for txt in ax.texts:
+            if '20 µm' in txt.get_text():
+                font_size_scaled = txt.get_fontsize()
+        for collection in ax.collections:
+            if collection.get_linewidth():
+                linewidth_scaled = collection.get_linewidth()[0]
+
+    assert font_size_scaled is not None
+    assert font_size_scaled > font_size_unscaled
+
+def test_scale_bar_logic_regression():
+    from eigenp_utils.tnia_plotting_anywidgets import show_zyx_max_slice_interactive
+    import numpy as np
+
+    im = np.zeros((50, 100, 150))
+    w_slice_1 = show_zyx_max_slice_interactive(im, pixel_sizes=(1, 1, 1), figsize=(5,5), figsize_scale=1.0)
+    fig_1 = w_slice_1._render()
+
+    w_slice_2 = show_zyx_max_slice_interactive(im, pixel_sizes=(1, 1, 1), figsize=(5,5), figsize_scale=2.0)
+    fig_2 = w_slice_2._render()
+
+    texts_1 = [txt.get_text() for ax in fig_1.axes for txt in ax.texts]
+    texts_2 = [txt.get_text() for ax in fig_2.axes for txt in ax.texts]
+
+    # Length logic shouldn't change with figsize
+    assert '10 µm' in texts_1
+    assert '10 µm' in texts_2
+
+    # But styling should scale
+    font_size_1 = next((txt.get_fontsize() for ax in fig_1.axes for txt in ax.texts if '10 µm' in txt.get_text()), None)
+    font_size_2 = next((txt.get_fontsize() for ax in fig_2.axes for txt in ax.texts if '10 µm' in txt.get_text()), None)
+
+    assert font_size_1 is not None and font_size_2 is not None
+    assert font_size_2 > font_size_1


### PR DESCRIPTION
Consolidates the AnyWidget plotting utilities to compute scale bars consistently using physical `sz` parameter width mapping, and guarantees proper scaling/resizing when modifying the `figsize_scale` UI argument.

---
*PR created automatically by Jules for task [14526368873432249933](https://jules.google.com/task/14526368873432249933) started by @eigenP*