### PR TITLE
fix: Use parsed pixel sizes for dynamic figsize calculation

### DIFF
--- a/src/eigenp_utils/tnia_plotting_anywidgets.py
+++ b/src/eigenp_utils/tnia_plotting_anywidgets.py
@@ -2122,9 +2122,7 @@ def show_zyx_max_slice_interactive(
         im = im[np.newaxis, ...]
     im_shape = (im[0].shape if isinstance(im, list) else im.shape)
     Z, Y, X = im_shape
-    _sxy = sxy if sxy is not None else 1
-    _sz = sz if sz is not None else 1
-    z_xy_ratio = (_sz / _sxy) if _sxy != _sz else 1
+    z_xy_ratio = (pz / px) if px != pz else 1
 
     if figsize is None:
         width_px  = X + Z * z_xy_ratio
@@ -2216,9 +2214,7 @@ def show_zyx_max_slice_interactive_point_annotator(
         im = im[np.newaxis, ...]
     im_shape = (im[0].shape if isinstance(im, list) else im.shape)
     Z, Y, X = im_shape
-    _sxy = sxy if sxy is not None else 1
-    _sz = sz if sz is not None else 1
-    z_xy_ratio = (_sz / _sxy) if _sxy != _sz else 1
+    z_xy_ratio = (pz / px) if px != pz else 1
 
     if figsize is None:
         width_px  = X + Z * z_xy_ratio
@@ -2348,9 +2344,7 @@ def show_zyx_max_scatter_interactive(
     XN = xmax - xmin + 1
     YN = ymax - ymin + 1
     ZN = zmax - zmin + 1
-    _sxy = sxy if sxy is not None else 1
-    _sz = sz if sz is not None else 1
-    z_xy_ratio = (_sz / _sxy) if _sxy != _sz else 1
+    z_xy_ratio = (pz / px) if px != pz else 1
 
     if figsize is None:
         width_px  = XN + ZN * z_xy_ratio

--- a/tests/test_tnia_plotting_anywidgets_spacing.py
+++ b/tests/test_tnia_plotting_anywidgets_spacing.py
@@ -1,0 +1,37 @@
+from eigenp_utils.tnia_plotting_anywidgets import show_zyx_max_slice_interactive, show_zyx_max_slabs, show_zyx
+import numpy as np
+import pytest
+
+def test_interactive_spacing_pixel_sizes_vs_sxy():
+    """
+    Test that when figsize is None, dynamically computed figsize uses
+    the same `z_xy_ratio` whether pixel_sizes=(Z, Y, X) or sxy=X, sz=Z is passed.
+    This ensures that axis spacing remains identical across both signatures.
+    """
+    im = np.random.rand(10, 50, 50)
+
+    # Using legacy sxy, sz
+    w_legacy = show_zyx_max_slice_interactive(im, sxy=1, sz=2)
+    fig_legacy = w_legacy._render()
+    size_legacy = fig_legacy.get_size_inches()
+
+    # Using pixel_sizes dict
+    w_dict = show_zyx_max_slice_interactive(im, pixel_sizes={'Z':2, 'Y':1, 'X':1})
+    fig_dict = w_dict._render()
+    size_dict = fig_dict.get_size_inches()
+
+    # Using pixel_sizes tuple
+    w_tuple = show_zyx_max_slice_interactive(im, pixel_sizes=(2, 1, 1))
+    fig_tuple = w_tuple._render()
+    size_tuple = fig_tuple.get_size_inches()
+
+    np.testing.assert_allclose(size_legacy, size_dict)
+    np.testing.assert_allclose(size_legacy, size_tuple)
+
+    # Test the height ratios generated inside the gridspec
+    gs_legacy = fig_legacy.axes[0].get_subplotspec().get_gridspec().get_height_ratios()
+    gs_dict = fig_dict.axes[0].get_subplotspec().get_gridspec().get_height_ratios()
+    gs_tuple = fig_tuple.axes[0].get_subplotspec().get_gridspec().get_height_ratios()
+
+    assert gs_legacy == gs_dict
+    assert gs_legacy == gs_tuple


### PR DESCRIPTION
Fixes an issue where providing `pixel_sizes` instead of the legacy `sxy` and `sz` arguments resulted in improper axis spacing and aspect ratios when `figsize` was dynamically computed in widget plotting utilities. Added a regression test to verify that the spacing generated matches between legacy kwargs and pixel sizes.

---
*PR created automatically by Jules for task [5925586522196919505](https://jules.google.com/task/5925586522196919505) started by @eigenP*