### PR TITLE
Fix adjust_brightness_per_slice diagnostic figure rendering bug

### DIFF
--- a/src/eigenp_utils/intensity_rescaling.py
+++ b/src/eigenp_utils/intensity_rescaling.py
@@ -227,7 +227,6 @@ def adjust_brightness_per_slice(image, final_gamma=0.8, gamma_fit_func=None, FLI
 
     # Create an output image array
     adjusted_image = np.empty_like(image)
-    diagnostic_fig = None
 
     # Pre-calculate global max for clipping logic if needed
     is_integer = np.issubdtype(image.dtype, np.integer)
@@ -290,21 +289,16 @@ def adjust_brightness_per_slice(image, final_gamma=0.8, gamma_fit_func=None, FLI
         except Exception as e:
             print(f"Warning: Curve fit failed: {e}. Returning original image.")
             if return_diagnostic:
-                return {"image": image, "figure": None}
+                return {"image": image, "diagnostic_data": None}
             return image
 
         if return_diagnostic:
-            import matplotlib.pyplot as plt
-            diagnostic_fig = plt.figure(figsize=(8, 5))
-            plt.plot(x_data, y_data_norm, 'o', label='Raw 99th Percentile (Normalized)', alpha=0.7)
-            plt.plot(x_data, y_fit_norm, '-', label=f'Fitted Curve ({gamma_fit_func})', linewidth=2)
-            plt.xlabel('Z-slice index')
-            plt.ylabel('Normalized Intensity')
-            plt.title('Z-axis Intensity Decay Fit')
-            plt.legend()
-            plt.grid(True, linestyle='--', alpha=0.6)
-            plt.tight_layout()
-            plt.close(diagnostic_fig)
+            diagnostic_data = {
+                "x_data": x_data,
+                "y_data_norm": y_data_norm,
+                "y_fit_norm": y_fit_norm,
+                "gamma_fit_func": gamma_fit_func
+            }
 
         # 4. Calculate correction factors (gamma or gain)
         y_ref_norm = np.max(y_fit_norm)
@@ -368,7 +362,7 @@ def adjust_brightness_per_slice(image, final_gamma=0.8, gamma_fit_func=None, FLI
                 adjusted_image[i, :, :] = img_slice.astype(image.dtype)
 
     if return_diagnostic:
-        return {"image": adjusted_image, "figure": diagnostic_fig}
+        return {"image": adjusted_image, "diagnostic_data": diagnostic_data if gamma_fit_func is not None else None}
     return adjusted_image
 
 def contrast_stretch_per_slice(image, p_min_array=None, p_max_array=None, FLIP_Z_AXIS=False):

--- a/src/eigenp_utils/plotting_utils.py
+++ b/src/eigenp_utils/plotting_utils.py
@@ -949,3 +949,33 @@ def savefig_svg(filename, bgnd_color=(1, 1, 1, 0.8), bbox_inches='tight', dpi=30
         **kwargs
     )
     print(f"Saved figure to {filename_str}")
+
+def brightness_diagnostic_plotter(diagnostic_data):
+    """
+    Plots the diagnostic data returned by `adjust_brightness_per_slice` when `return_diagnostic=True`.
+
+    Args:
+        diagnostic_data (dict): The diagnostic data containing `x_data`, `y_data_norm`, `y_fit_norm`, and `gamma_fit_func`.
+
+    Returns:
+        matplotlib.figure.Figure: The diagnostic figure.
+    """
+    if diagnostic_data is None:
+        return None
+
+    x_data = diagnostic_data['x_data']
+    y_data_norm = diagnostic_data['y_data_norm']
+    y_fit_norm = diagnostic_data['y_fit_norm']
+    gamma_fit_func = diagnostic_data['gamma_fit_func']
+
+    fig = plt.figure(figsize=(8, 5))
+    plt.plot(x_data, y_data_norm, 'o', label='Raw 99th Percentile (Normalized)', alpha=0.7)
+    plt.plot(x_data, y_fit_norm, '-', label=f'Fitted Curve ({gamma_fit_func})', linewidth=2)
+    plt.xlabel('Z-slice index')
+    plt.ylabel('Normalized Intensity')
+    plt.title('Z-axis Intensity Decay Fit')
+    plt.legend()
+    plt.grid(True, linestyle='--', alpha=0.6)
+    plt.tight_layout()
+
+    return fig

--- a/tests/test_brightness_invariants.py
+++ b/tests/test_brightness_invariants.py
@@ -175,17 +175,26 @@ def test_idempotence():
         f"Algorithm is not idempotent; second pass changed values by {max_rel_diff*100:.4f}%"
 
 def test_return_diagnostic_dict():
-    import matplotlib.pyplot as plt
     image = np.random.randint(0, 255, (10, 20, 20), dtype=np.uint8)
 
-    # Test that it returns a dictionary with 'image' and 'figure'
+    # Test that it returns a dictionary with 'image' and 'diagnostic_data'
     result = adjust_brightness_per_slice(image, gamma_fit_func='exponential', return_diagnostic=True)
 
     assert isinstance(result, dict)
     assert 'image' in result
-    assert 'figure' in result
+    assert 'diagnostic_data' in result
     assert isinstance(result['image'], np.ndarray)
 
-    # Figure should be a matplotlib Figure object
+    diag_data = result['diagnostic_data']
+    assert isinstance(diag_data, dict)
+    assert 'x_data' in diag_data
+    assert 'y_data_norm' in diag_data
+    assert 'y_fit_norm' in diag_data
+    assert 'gamma_fit_func' in diag_data
+
+    # Test plotting function
+    from eigenp_utils.plotting_utils import brightness_diagnostic_plotter
     from matplotlib.figure import Figure
-    assert isinstance(result['figure'], Figure)
+
+    fig = brightness_diagnostic_plotter(diag_data)
+    assert isinstance(fig, Figure)


### PR DESCRIPTION
Fixes a bug where `adjust_brightness_per_slice(..., return_diagnostic=True)` returned an unrenderable `None` or closed figure in notebook environments because `plt.close(diagnostic_fig)` was called before returning the figure.

Changes:
- Refactored `adjust_brightness_per_slice` to return the `x_data`, `y_data_norm`, `y_fit_norm`, and `gamma_fit_func` arrays inside a `diagnostic_data` dict.
- Added a new `brightness_diagnostic_plotter` function in `plotting_utils.py` to construct the plot from this data cleanly.
- Updated `test_brightness_invariants.py` to test the new data format and plotter function.

---
*PR created automatically by Jules for task [1252858796589491042](https://jules.google.com/task/1252858796589491042) started by @eigenP*