### PR TITLE
Fix Intensity Rescaling Decorator Behavior

### DIFF
--- a/src/eigenp_utils/intensity_rescaling.py
+++ b/src/eigenp_utils/intensity_rescaling.py
@@ -6,6 +6,63 @@ import scipy.ndimage as ndimage
 from scipy.fft import dctn, idctn
 import skimage.transform as transform
 
+
+def ensure_float_and_restore_dtype(func):
+    """
+    Decorator to safely convert input to float32 for processing,
+    and restore the original data type upon return without forcefully
+    stretching the intensity range.
+    """
+    def wrapper(image, *args, **kwargs):
+        orig_dtype = image.dtype
+        is_integer = np.issubdtype(orig_dtype, np.integer)
+
+        # Determine valid bounds for clipping if original is integer
+        if is_integer:
+            info = np.iinfo(orig_dtype)
+            valid_min, valid_max = info.min, info.max
+
+        # Convert to float32 only if it isn't already a float
+        if not np.issubdtype(orig_dtype, np.floating):
+            image_float = image.astype(np.float32)
+        else:
+            image_float = image
+
+        # Execute the core function
+        result = func(image_float, *args, **kwargs)
+
+        def convert_output(arr):
+            # If the original was float, just cast back to original float precision
+            if not is_integer:
+                return arr.astype(orig_dtype)
+
+            # If original was integer, we must clip to prevent underflow/overflow wrap-around
+            # We do NOT rescale, we only clip out-of-bounds values.
+            if arr.max() > valid_max or arr.min() < valid_min:
+                warnings.warn(f"Values outside {orig_dtype} range were clipped to [{valid_min}, {valid_max}].")
+                arr = np.clip(arr, valid_min, valid_max)
+
+            # Round before casting to integer to avoid truncation errors
+            # (e.g., 254.9 becoming 254 instead of 255)
+            return np.round(arr).astype(orig_dtype)
+
+        # Handle tuple returns (rescale primary output only)
+        if isinstance(result, tuple):
+            primary = convert_output(result[0])
+            return (primary,) + result[1:]
+        elif isinstance(result, dict):
+            # Try to convert primary output if it exists in expected keys
+            if 'image' in result:
+                result['image'] = convert_output(result['image'])
+            elif 'corrected' in result:
+                result['corrected'] = convert_output(result['corrected'])
+            return result
+        else:
+            return convert_output(result)
+
+    return wrapper
+
+@ensure_float_and_restore_dtype
 def contrast_stretching(image, p_min=0.0, p_max=99.9):
     """
     Stretch the intensity range of the image based on percentiles.
@@ -56,14 +113,13 @@ def normalize_image(image, lower_percentile=0.5, upper_percentile=99.9, dtype=No
     if np.issubdtype(dtype, np.floating):
         return normalized_image.astype(dtype)
     elif np.issubdtype(dtype, np.integer):
-        # Scale to max value of the integer type (e.g., 255 for uint8)
         max_val = np.iinfo(dtype).max
         normalized_image *= max_val
         return normalized_image.astype(dtype)
     else:
-        # Fallback for other types
         return normalized_image.astype(dtype)
 
+@ensure_float_and_restore_dtype
 def adjust_gamma_per_slice(image, final_gamma=0.8, gamma_fit_func=None, FLIP_Z_AXIS=False):
     """
     Adjusts the gamma of each slice in a 3D image along the Z-axis.
@@ -195,6 +251,7 @@ def adjust_gamma_per_slice(image, final_gamma=0.8, gamma_fit_func=None, FLIP_Z_A
 
     return adjusted_image
 
+@ensure_float_and_restore_dtype
 def adjust_brightness_per_slice(image, final_gamma=0.8, gamma_fit_func=None, FLIP_Z_AXIS=False, method='gamma', return_diagnostic=False):
     """
     Adjusts the brightness of each slice in a 3D image along the Z-axis.

--- a/tests/test_intensity_rescaling.py
+++ b/tests/test_intensity_rescaling.py
@@ -162,3 +162,62 @@ def test_basic_fit_synthetic_ladmap_darkfield():
 
     max_error_ff = np.max(np.abs(flatfield - truth_flatfield))
     assert max_error_ff < 1.5, f"Max error {max_error_ff} exceeded 1.5 threshold"
+
+def test_ensure_float_and_restore_dtype_decorator():
+    from eigenp_utils.intensity_rescaling import ensure_float_and_restore_dtype
+    import warnings
+
+    @ensure_float_and_restore_dtype
+    def dummy_func_mult(img, factor):
+        # Function receives a float32 implicitly via decorator
+        assert np.issubdtype(img.dtype, np.floating)
+        return img * factor
+
+    @ensure_float_and_restore_dtype
+    def dummy_func_tuple(img):
+        return img * 2.0, "metadata"
+
+    # Test Float
+    img_float = np.array([0.1, 0.5, 0.9], dtype=np.float64)
+    res_float = dummy_func_mult(img_float, 2.0)
+    assert res_float.dtype == np.float64
+    np.testing.assert_allclose(res_float, [0.2, 1.0, 1.8])
+
+    # Test Uint8 normal range
+    img_uint8 = np.array([10, 50, 100], dtype=np.uint8)
+    res_uint8 = dummy_func_mult(img_uint8, 2.0)
+    assert res_uint8.dtype == np.uint8
+    np.testing.assert_equal(res_uint8, [20, 100, 200])
+
+    # Test Uint8 overflow clipping and rounding
+    img_uint8_overflow = np.array([10, 150, 200], dtype=np.uint8)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        res_overflow = dummy_func_mult(img_uint8_overflow, 2.0)
+        assert len(w) == 1
+        assert "Values outside uint8 range were clipped" in str(w[-1].message)
+
+    assert res_overflow.dtype == np.uint8
+    np.testing.assert_equal(res_overflow, [20, 255, 255])
+
+    # Test Uint8 underflow clipping
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        res_underflow = dummy_func_mult(img_uint8_overflow, -1.0)
+        assert len(w) == 1
+        assert "Values outside uint8 range were clipped" in str(w[-1].message)
+    np.testing.assert_equal(res_underflow, [0, 0, 0])
+
+    # Test float16
+    img_float16 = np.array([1.0, 2.0], dtype=np.float16)
+    res_float16 = dummy_func_mult(img_float16, 2.0)
+    assert res_float16.dtype == np.float16
+    np.testing.assert_allclose(res_float16, [2.0, 4.0])
+
+    # Test Tuple return
+    res_tuple = dummy_func_tuple(img_uint8)
+    assert isinstance(res_tuple, tuple)
+    assert len(res_tuple) == 2
+    assert res_tuple[0].dtype == np.uint8
+    np.testing.assert_equal(res_tuple[0], [20, 100, 200])
+    assert res_tuple[1] == "metadata"


### PR DESCRIPTION
The user pointed out a mathematical paradox in applying an aggressive `@preserve_intensity_format` decorator to an intensity rescaling module where functions explicitly change the data bounds. We have introduced the correct, requested decorator `ensure_float_and_restore_dtype` that processes dynamically in `float32` and safely caps back down to original bounds for standard integer types (e.g., `uint8`) using `.clip()` rather than `.rescale()`. 

The decorator supports both direct numpy array returns, Tuple returns, and Dictionary returns with known keys (`'image'`, `'corrected'`). It was carefully applied to relevant pure rescaling functions like `contrast_stretching` and `adjust_brightness_per_slice` without breaking custom kwarg behavior on normalization and basic shading. The changes are accompanied by extensive unit testing.

---
*PR created automatically by Jules for task [9315037899082640710](https://jules.google.com/task/9315037899082640710) started by @eigenP*