### PR TITLE
feat: Add rasterization thresholds for scatter plots

### DIFF
--- a/src/eigenp_utils/plotting_utils.py
+++ b/src/eigenp_utils/plotting_utils.py
@@ -227,7 +227,8 @@ def raincloud_plot(data,
                    linewidth_scatter=0.5,
                    linewidth_boxplot=8,
                    offset_scatter=0.20,
-                   width_violin=0.5):
+                   width_violin=0.5,
+                   raster_threshold=None):
     """
     Creates a raincloud plot (half-violin + boxplot + jittered scatter).
 
@@ -262,6 +263,10 @@ def raincloud_plot(data,
     dodge : bool, optional
         When hue is nested, whether to draw elements at different positions.
         If None, defaults to True unless hue matches x or y variable.
+    raster_threshold : int, optional
+        If the total number of scatter points across all groups exceeds this threshold,
+        the jittered scatter points will be rasterized. This is useful for keeping SVG
+        file sizes small when there are many points.
 
     Returns
     -------
@@ -511,7 +516,13 @@ def raincloud_plot(data,
             xtick_positions.append(i)
             xtick_labels.append(label)
 
-    # --- 2. Setup Figure/Axes ---
+    # --- 2. Calculate Total Points for Rasterization ---
+    total_points = sum(len(item['values']) for item in plot_items)
+    rasterize_scatter = False
+    if raster_threshold is not None and total_points > raster_threshold:
+        rasterize_scatter = True
+
+    # --- 3. Setup Figure/Axes ---
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
     else:
@@ -561,7 +572,8 @@ def raincloud_plot(data,
             y_scatter = pos - offset + jitter_vals
 
         ax.scatter(x_scatter, y_scatter, color=col, alpha=alpha_scatter,
-                   edgecolor="black", linewidth=linewidth_scatter, s=size_scatter)
+                   edgecolor="black", linewidth=linewidth_scatter, s=size_scatter,
+                   rasterized=rasterize_scatter)
 
         # C. Boxplot Elements (Median + IQR)
         q1, med, q3 = np.percentile(vals, [25, 50, 75])
@@ -903,7 +915,7 @@ def get_nice_number(value):
     return int(nice_fraction * (10 ** exponent))
 
 
-def savefig_svg(filename, bgnd_color=(1, 1, 1, 0.8), bbox_inches='tight', dpi=300, pad_inches=0.1, **kwargs):
+def savefig_svg(filename, bgnd_color=(1, 1, 1, 0.8), bbox_inches='tight', dpi=300, pad_inches=0.1, scatter_raster_threshold=None, **kwargs):
     """
     Saves the currently active matplotlib figure as an SVG file.
 
@@ -919,6 +931,10 @@ def savefig_svg(filename, bgnd_color=(1, 1, 1, 0.8), bbox_inches='tight', dpi=30
         The resolution in dots per inch for rasterized elements.
     pad_inches : float, default 0.1
         Amount of padding around the figure when bbox_inches is 'tight'.
+    scatter_raster_threshold : int, optional
+        If provided, any scatter plot (PathCollection) in the figure containing
+        this number of points or more will be rasterized before saving. This
+        helps keep SVG file sizes manageable for large datasets.
     **kwargs :
         Additional keyword arguments passed directly to `plt.savefig`.
     """
@@ -932,6 +948,16 @@ def savefig_svg(filename, bgnd_color=(1, 1, 1, 0.8), bbox_inches='tight', dpi=30
     metadata.setdefault('Creator', 'eigenp')
     metadata.setdefault('Date', datetime.datetime.now().isoformat())
     metadata.setdefault('Title', title)
+
+    # Rasterize scatter collections if threshold is met
+    if scatter_raster_threshold is not None:
+        from matplotlib.collections import PathCollection
+        for ax in fig.axes:
+            for collection in ax.collections:
+                if isinstance(collection, PathCollection):
+                    # Check the number of offsets (points) in the scatter
+                    if len(collection.get_offsets()) >= scatter_raster_threshold:
+                        collection.set_rasterized(True)
 
     # Make sure we add '.svg' if it's not present
     filename_str = str(filename)

--- a/src/eigenp_utils/plotting_utils.py
+++ b/src/eigenp_utils/plotting_utils.py
@@ -228,7 +228,7 @@ def raincloud_plot(data,
                    linewidth_boxplot=8,
                    offset_scatter=0.20,
                    width_violin=0.5,
-                   raster_threshold=None):
+                   raster_threshold=1e3):
     """
     Creates a raincloud plot (half-violin + boxplot + jittered scatter).
 

--- a/src/eigenp_utils/plotting_utils.py
+++ b/src/eigenp_utils/plotting_utils.py
@@ -915,7 +915,7 @@ def get_nice_number(value):
     return int(nice_fraction * (10 ** exponent))
 
 
-def savefig_svg(filename, bgnd_color=(1, 1, 1, 0.8), bbox_inches='tight', dpi=300, pad_inches=0.1, scatter_raster_threshold=None, **kwargs):
+def savefig_svg(filename, bgnd_color=(1, 1, 1, 0.8), bbox_inches='tight', dpi=300, pad_inches=0.1, scatter_raster_threshold=1e3, **kwargs):
     """
     Saves the currently active matplotlib figure as an SVG file.
 

--- a/tests/test_raincloud_plot.py
+++ b/tests/test_raincloud_plot.py
@@ -132,3 +132,67 @@ def test_savefig_svg_raster_threshold(tmp_path):
     # Both SVG files should have been created
     assert out_file1.exists()
     assert out_file2.exists()
+
+
+
+def test_savefig_svg_raster_threshold_size(tmp_path):
+    from eigenp_utils.plotting_utils import savefig_svg
+    import pandas as pd
+    from matplotlib.collections import PathCollection
+
+    # --- Original Test Case: State Checks ---
+    fig, ax = plt.subplots()
+    # 100 points
+    ax.scatter(range(100), range(100))
+
+    # Initially not rasterized
+    scatter_col = [c for c in ax.collections if isinstance(c, PathCollection)][0]
+    assert scatter_col.get_rasterized() is False
+
+    # Call savefig_svg with threshold 500 (not met)
+    out_file1 = tmp_path / "test_no_raster.svg"
+    savefig_svg(out_file1, scatter_raster_threshold=500)
+
+    # Should still not be rasterized
+    assert scatter_col.get_rasterized() is False
+
+    # Call savefig_svg with threshold 50 (met)
+    out_file2 = tmp_path / "test_raster.svg"
+    savefig_svg(out_file2, scatter_raster_threshold=50)
+
+    # Should now be rasterized
+    assert scatter_col.get_rasterized() is True
+
+    # Both SVG files should have been created
+    assert out_file1.exists()
+    assert out_file2.exists()
+    
+    plt.close(fig)
+
+    # --- Added Test Case: File Size Verification ---
+    fig_size, ax_size = plt.subplots()
+    
+    # 2e3 points
+    n_points = 2000
+    x = np.random.rand(n_points)
+    y = np.random.rand(n_points)
+    ax_size.scatter(x, y)
+
+    out_file_vector = tmp_path / "test_size_vector.svg"
+    out_file_raster = tmp_path / "test_size_raster.svg"
+
+    # Save with threshold 3e3 (threshold not met -> pure vector representation)
+    savefig_svg(out_file_vector, scatter_raster_threshold=3000, dpi=100)
+    
+    # Save with threshold 1e3 (threshold met -> scatter paths rasterized)
+    savefig_svg(out_file_raster, scatter_raster_threshold=1000, dpi=100)
+
+    # Compare file sizes on disk
+    size_vector = out_file_vector.stat().st_size
+    size_raster = out_file_raster.stat().st_size
+
+    # The rasterized SVG embeds a base64 encoded PNG, avoiding rendering O(N) path objects.
+    # It must yield a strictly smaller file size at this density.
+    assert size_raster < size_vector
+
+    plt.close(fig_size)

--- a/tests/test_raincloud_plot.py
+++ b/tests/test_raincloud_plot.py
@@ -74,3 +74,61 @@ def test_raincloud_plot_with_kwargs():
     )
     assert res is not None
     assert 'axes' in res
+
+def test_raincloud_plot_raster_threshold():
+    import pandas as pd
+    from matplotlib.collections import PathCollection
+
+    # Total points = 10 (less than 50 threshold)
+    data_small = pd.DataFrame({'group': ['A']*5 + ['B']*5, 'value': range(10)})
+    res_small = raincloud_plot(data=data_small, x='group', y='value', raster_threshold=50)
+    ax_small = res_small['axes']
+
+    # Find scatter collections (we expect them not to be rasterized)
+    scatter_collections_small = [c for c in ax_small.collections if isinstance(c, PathCollection) and len(c.get_offsets()) == 5]
+    assert len(scatter_collections_small) > 0
+    for c in scatter_collections_small:
+        assert c.get_rasterized() is False
+
+    # Total points = 100 (greater than 50 threshold)
+    data_large = pd.DataFrame({'group': ['A']*50 + ['B']*50, 'value': range(100)})
+    res_large = raincloud_plot(data=data_large, x='group', y='value', raster_threshold=50)
+    ax_large = res_large['axes']
+
+    scatter_collections_large = [c for c in ax_large.collections if isinstance(c, PathCollection) and len(c.get_offsets()) == 50]
+    assert len(scatter_collections_large) > 0
+    for c in scatter_collections_large:
+        # these scatter collections should be rasterized
+        assert c.get_rasterized() is True
+
+def test_savefig_svg_raster_threshold(tmp_path):
+    from eigenp_utils.plotting_utils import savefig_svg
+    import pandas as pd
+    from matplotlib.collections import PathCollection
+
+    # Create a simple figure with a scatter plot
+    fig, ax = plt.subplots()
+    # 100 points
+    ax.scatter(range(100), range(100))
+
+    # Initially not rasterized
+    scatter_col = [c for c in ax.collections if isinstance(c, PathCollection)][0]
+    assert scatter_col.get_rasterized() is False
+
+    # Call savefig_svg with threshold 500 (not met)
+    out_file1 = tmp_path / "test_no_raster.svg"
+    savefig_svg(out_file1, scatter_raster_threshold=500)
+
+    # Should still not be rasterized
+    assert scatter_col.get_rasterized() is False
+
+    # Call savefig_svg with threshold 50 (met)
+    out_file2 = tmp_path / "test_raster.svg"
+    savefig_svg(out_file2, scatter_raster_threshold=50)
+
+    # Should now be rasterized
+    assert scatter_col.get_rasterized() is True
+
+    # Both SVG files should have been created
+    assert out_file1.exists()
+    assert out_file2.exists()


### PR DESCRIPTION
Added options to selectively rasterize large scatter plots in `raincloud_plot` and `savefig_svg` to minimize SVG export sizes while retaining vector formats for the rest of the figure components.

---
*PR created automatically by Jules for task [7058066598138551662](https://jules.google.com/task/7058066598138551662) started by @eigenP*