### PR TITLE
Fix interactive 3D widgets to handle slabs thickness in physical units

### DIFF
--- a/src/eigenp_utils/tnia_plotting_anywidgets.py
+++ b/src/eigenp_utils/tnia_plotting_anywidgets.py
@@ -1226,14 +1226,33 @@ class TNIASliceWidget(TNIAWidgetBase):
         self.gamma_list = _to_list(gamma, self.num_channels, 1.0)
         self.opacity_list = _to_list(opacity, self.num_channels, 1.0)
 
-        # Set initial values if provided
-        if x_t is not None: self.x_t = int(x_t)
-        if y_t is not None: self.y_t = int(y_t)
-        if z_t is not None: self.z_t = int(z_t)
+        # Convert physical position/thickness to pixel indices
+        def _default_t(n): return max(1, n // 64)
+        x_t_idx = int(round(x_t / px)) if x_t is not None else _default_t(X)
+        y_t_idx = int(round(y_t / py)) if y_t is not None else _default_t(Y)
+        z_t_idx = int(round(z_t / pz)) if z_t is not None else _default_t(Z)
 
-        if x_s is not None: self.x_s = int(x_s)
-        if y_s is not None: self.y_s = int(y_s)
-        if z_s is not None: self.z_s = int(z_s)
+        x_s_idx = int(round(x_s / px)) if x_s is not None else X // 2
+        y_s_idx = int(round(y_s / py)) if y_s is not None else Y // 2
+        z_s_idx = int(round(z_s / pz)) if z_s is not None else Z // 2
+
+        # Override for max projection if thickness exceeds shape
+        if x_t_idx >= X:
+            x_t_idx = max(1, X // 2)
+            x_s_idx = X // 2
+        if y_t_idx >= Y:
+            y_t_idx = max(1, Y // 2)
+            y_s_idx = Y // 2
+        if z_t_idx >= Z:
+            z_t_idx = max(1, Z // 2)
+            z_s_idx = Z // 2
+
+        self.x_t = x_t_idx
+        self.y_t = y_t_idx
+        self.z_t = z_t_idx
+        self.x_s = x_s_idx
+        self.y_s = y_s_idx
+        self.z_s = z_s_idx
 
         # Compute histograms
         hists = []

--- a/tests/test_tnia_plotting_anywidgets.py
+++ b/tests/test_tnia_plotting_anywidgets.py
@@ -172,9 +172,15 @@ def test_interactive_kwargs_images(factory_fn):
 
     assert w.show_crosshair is False
     assert w.sync_on_hover is True
-    assert w.z_t == 2 and w.y_t == 3 and w.x_t == 4
-    # Note: slabs_position clamped because random coords are [0, 1] mapped to Dim=2
-    assert w.z_s == 5 and w.y_s == 10 and w.x_s == 15
+    # Because pixel_sizes are set to Z=2.0, Y=1.0, X=0.5
+    # slabs_thickness in physical units: (2, 3, 4)
+    # The indices will be calculated as thickness // p => (2/2.0=1, 3/1.0=3, 4/0.5=8)
+    assert w.z_t == 1 and w.y_t == 3 and w.x_t == 8
+
+    # Note: slabs_position in physical units: (5, 10, 15)
+    # The indices will be calculated as pos // p => (5/2.0=2.5->2, 10/1.0=10, 15/0.5=30)
+    # clamped because coords map to dims [10, 20, 30] (max 9, 19, 29)
+    assert w.z_s == 2 and w.y_s == 10 and w.x_s == 29
     assert w.sz == 2.0 and w.sy == 1.0 and w.sx == 0.5
 
 def test_interactive_kwargs_scatter():


### PR DESCRIPTION
Fixes an issue where `slabs_thickness` in interactive 3D viewers (`show_zyx_max_slice_interactive`) was previously treated as raw pixel counts rather than physical units.

### Changes
- The input physical parameters `slabs_thickness` and `slabs_position` are now correctly interpreted as physical distances using the `pixel_sizes` scaling factor.
- `TNIASliceWidget.__init__` and `TNIAScatterWidget.__init__` now encapsulate this scaling logic securely alongside internal boundary clamping (ensuring projections don't exceed max possible dimensions).
- `show_zyx_max_slice_interactive`, `show_zyx_max_slice_interactive_point_annotator`, and `show_zyx_max_scatter_interactive` wrapper functions have been vastly simplified by relying on widget constructors.
- Added tests asserting accurate unit scaling functionality.

---
*PR created automatically by Jules for task [8390967306718046891](https://jules.google.com/task/8390967306718046891) started by @eigenP*