### PR TITLE
Fix floating point parsing and zero-sized slices in anywidgets

### DIFF
--- a/src/eigenp_utils/tnia_plotting_anywidgets.py
+++ b/src/eigenp_utils/tnia_plotting_anywidgets.py
@@ -12,13 +12,32 @@
 import pathlib
 import warnings
 
+def _safe_float(v):
+    if v is None:
+        return None
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        # Handle zero-dimensional numpy arrays like np.array(1.5)
+        if hasattr(v, 'size') and v.size == 1 and hasattr(v, 'item'):
+            return float(v.item())
+        raise ValueError(f"Could not convert {v} to float")
+
 def _parse_zyx_tuple_or_dict(val, default_val=None):
     if val is None:
         return (default_val, default_val, default_val)
     if isinstance(val, dict):
-        return (val.get('Z', default_val), val.get('Y', default_val), val.get('X', default_val))
-    if isinstance(val, (list, tuple)) and len(val) == 3:
-        return val
+        return (_safe_float(val.get('Z', default_val)),
+                _safe_float(val.get('Y', default_val)),
+                _safe_float(val.get('X', default_val)))
+
+    try:
+        val_list = list(val)
+        if len(val_list) == 3:
+            return (_safe_float(val_list[0]), _safe_float(val_list[1]), _safe_float(val_list[2]))
+    except TypeError:
+        pass
+
     raise ValueError(f"Expected dict with 'Z','Y','X' keys or a 3-element tuple/list, got {val}")
 
 import anywidget
@@ -375,10 +394,14 @@ def show_zyx_max_slabs(image_to_show, x=[0,1], y=[0,1], z=[0,1], pixel_sizes=Non
             _sz = sz if sz is not None else 1.0
             pixel_sizes = (_sz, _sxy, _sxy)
 
-    ### Coerce into integers for slices
-    x_ = [int(i) for i in x]
-    y_ = [int(i) for i in y]
-    z_ = [int(i) for i in z]
+    ### Coerce into integers for slices, rounding floats and ensuring non-zero bounds
+    x_ = [int(np.round(float(i))) for i in x]
+    y_ = [int(np.round(float(i))) for i in y]
+    z_ = [int(np.round(float(i))) for i in z]
+
+    if x_[1] <= x_[0]: x_[1] = x_[0] + 1
+    if y_[1] <= y_[0]: y_[1] = y_[0] + 1
+    if z_[1] <= z_[0]: z_[1] = z_[0] + 1
 
     x_slices = slice(*x_)
     y_slices = slice(*y_)

--- a/tests/test_tnia_plotting_anywidgets.py
+++ b/tests/test_tnia_plotting_anywidgets.py
@@ -266,3 +266,48 @@ def test_scale_bar_logic(shape, pixel_sizes, expected_text):
 
     assert font_size_scaled is not None
     assert font_size_scaled > font_size_unscaled
+
+def test_parse_zyx_tuple_or_dict_various_types():
+    from eigenp_utils.tnia_plotting_anywidgets import _parse_zyx_tuple_or_dict
+
+    # 1. Native tuple of floats
+    res = _parse_zyx_tuple_or_dict((1.5, 2.5, 3.5))
+    assert res == (1.5, 2.5, 3.5)
+
+    # 2. Native list of floats
+    res = _parse_zyx_tuple_or_dict([1.5, 2.5, 3.5])
+    assert res == (1.5, 2.5, 3.5)
+
+    # 3. Dict with floats
+    res = _parse_zyx_tuple_or_dict({'Z': 1.5, 'Y': 2.5, 'X': 3.5})
+    assert res == (1.5, 2.5, 3.5)
+
+    # 4. Tuple with np.ndarrays (0-d arrays / scalars)
+    res = _parse_zyx_tuple_or_dict((np.array(1.5), np.array(2.5), np.array(3.5)))
+    assert res == (1.5, 2.5, 3.5)
+    assert isinstance(res[0], float)
+
+    # 5. Dict with np.ndarrays
+    res = _parse_zyx_tuple_or_dict({'Z': np.array(1.5), 'Y': np.array(2.5), 'X': np.array(3.5)})
+    assert res == (1.5, 2.5, 3.5)
+    assert isinstance(res[0], float)
+
+    # 6. Very small/large values
+    res = _parse_zyx_tuple_or_dict([1e-6, 1e6, 0.0])
+    assert res == (1e-6, 1e6, 0.0)
+
+def test_show_zyx_max_slabs_zero_sized_slices():
+    from eigenp_utils.tnia_plotting_anywidgets import show_zyx_max_slabs, show_zyx_max_slice_interactive
+    im = np.random.rand(10, 10, 10)
+
+    # Passing identical float intervals, should be coerced to integer intervals
+    # of size 1 (i.e. x=[0, 1]) without raising a ValueError.
+    fig = show_zyx_max_slabs(im, x=[0.5, 0.5], y=[0.0, 0.0], z=[0, 0])
+    assert fig is not None
+
+    # Additionally test the interactive wrapper passing 0-d np scalars
+    w = show_zyx_max_slice_interactive(im, pixel_sizes=(np.array(1.5), np.array(2.5), np.array(3.5)))
+    assert w.sz == 1.5
+    assert w.sy == 2.5
+    assert w.sx == 3.5
+    assert isinstance(w.sz, float)


### PR DESCRIPTION
This submission fixes the bugs preventing the rendering of widgets and projection slabs when float values or 0-dimensional numpy arrays were given as inputs for spatial properties or interval boundaries.

---
*PR created automatically by Jules for task [8668411899579512013](https://jules.google.com/task/8668411899579512013) started by @eigenP*