### PR TITLE
Fix misleading TraitError on Colormap instances in plotting widgets

### DIFF
--- a/src/eigenp_utils/tnia_plotting_anywidgets.py
+++ b/src/eigenp_utils/tnia_plotting_anywidgets.py
@@ -73,6 +73,12 @@ def resolve_color(c):
     Attempts to resolve a string to a valid matplotlib color.
     If it is a valid colormap name, it returns the final color (at 1.0) of that colormap.
     """
+    if isinstance(c, mcolors.Colormap):
+        raise TypeError(
+            f"Expected a registered colormap name or color as a string (e.g., 'viridis' or 'red'), "
+            f"but got a Colormap instance: {c}. Please pass the string name of the registered colormap."
+        )
+
     if not isinstance(c, str):
         return c
 

--- a/tests/test_tnia_plotting_anywidgets_resolve_color.py
+++ b/tests/test_tnia_plotting_anywidgets_resolve_color.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pytest
+import matplotlib.colors as mcolors
+from eigenp_utils.tnia_plotting_anywidgets import resolve_color, show_zyx_max_slice_interactive
+from eigenp_utils.plotting_utils import labels_cmap
+
+def test_resolve_color():
+    # Test hex colors
+    assert resolve_color("#ff0000") == "#ff0000"
+
+    # Test valid colormap names
+    assert resolve_color("viridis") == "#fde725" # final color of viridis
+
+    # Test colormap instances directly raise TypeError
+    cmap = mcolors.LinearSegmentedColormap.from_list('test', ['black', 'white'])
+    with pytest.raises(TypeError, match="Expected a registered colormap name"):
+        resolve_color(cmap)
+
+    # Test actual labels_cmap issue from prompt
+    with pytest.raises(TypeError, match="Expected a registered colormap name"):
+        resolve_color(labels_cmap)
+
+def test_widget_rejects_colormap_instance():
+    im = np.zeros((10, 20, 30))
+    # This crashed previously due to channel_colors list expecting a unicode string but getting a Colormap instance
+    with pytest.raises(TypeError, match="Expected a registered colormap name"):
+        w = show_zyx_max_slice_interactive(im, colormap=labels_cmap)


### PR DESCRIPTION
Intercept invalid colormap inputs in `resolve_color` by checking for `matplotlib.colors.Colormap` instances and raising an immediate, descriptive `TypeError`. This prevents confusing traitlets validation errors down the line when widget classes attempt to serialize colormap definitions. Added corresponding unit tests.

---
*PR created automatically by Jules for task [13930262103204651360](https://jules.google.com/task/13930262103204651360) started by @eigenP*