### PR TITLE
Fix: Make statannotations an optional dependency

### DIFF
--- a/src/eigenp_utils/stats.py
+++ b/src/eigenp_utils/stats.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-from statannotations.Annotator import Annotator
 from scipy import stats
 
 def add_stat_annotations(
@@ -54,6 +53,15 @@ def add_stat_annotations(
     (matplotlib.axes.Axes, statannotations.Annotator)
         If return_annotator is True.
     """
+    try:
+        from statannotations.Annotator import Annotator
+    except ImportError:
+        raise ImportError(
+            "The 'statannotations' package is required for add_stat_annotations. "
+            "Please install it using 'pip install statannotations' or "
+            "'pip install eigenp_utils[plotting]'."
+        )
+
     annotator = Annotator(ax, pairs, data=data, x=x, y=y, hue=hue)
     annotator.configure(
         test=test,


### PR DESCRIPTION
This commit fixes a bug where `eigenp_utils` would fail to import if the `statannotations` package (part of the `plotting` optional dependency group) was missing. By shifting the import to a local scope within `add_stat_annotations` and handling the `ImportError` safely, users can now install and use other parts of `eigenp_utils` (like `image-analysis`) without needing to install `statannotations`.

---
*PR created automatically by Jules for task [1293778599721768011](https://jules.google.com/task/1293778599721768011) started by @eigenP*