### PR TITLE
⚡ matth: exact Beta distribution for Mahalanobis outlier thresholds

### DIFF
--- a/src/eigenp_utils/stats.py
+++ b/src/eigenp_utils/stats.py
@@ -416,9 +416,14 @@ def remove_outliers(data, method='iqr', threshold=1.5, column=None):
                     left = np.dot(X_centered, inv_cov)
                     D_squared = np.sum(left * X_centered, axis=1)
 
-                    chi2_thresh = stats.chi2.ppf(threshold, df=n_features)
+                    if n_samples > n_features + 1:
+                        bound_multiplier = ((n_samples - 1) ** 2) / n_samples
+                        beta_thresh = stats.beta.ppf(threshold, n_features / 2, (n_samples - n_features - 1) / 2)
+                        thresh = bound_multiplier * beta_thresh
+                    else:
+                        thresh = stats.chi2.ppf(threshold, df=n_features)
 
-                    valid_keep = D_squared <= chi2_thresh
+                    valid_keep = D_squared <= thresh
                     bool_mask[valid_row_mask] = valid_keep
 
                 mask = pd.Series(bool_mask, index=df_out.index)
@@ -481,9 +486,14 @@ def remove_outliers(data, method='iqr', threshold=1.5, column=None):
                 left = np.dot(X_centered, inv_cov)
                 D_squared = np.sum(left * X_centered, axis=1)
 
-                chi2_thresh = stats.chi2.ppf(threshold, df=n_features)
+                if n_samples > n_features + 1:
+                    bound_multiplier = ((n_samples - 1) ** 2) / n_samples
+                    beta_thresh = stats.beta.ppf(threshold, n_features / 2, (n_samples - n_features - 1) / 2)
+                    thresh = bound_multiplier * beta_thresh
+                else:
+                    thresh = stats.chi2.ppf(threshold, df=n_features)
 
-                valid_keep = D_squared <= chi2_thresh
+                valid_keep = D_squared <= thresh
                 keep_mask[valid_row_mask] = valid_keep
 
             return values[keep_mask]


### PR DESCRIPTION
⚡ matth: exact Beta distribution for Mahalanobis outlier thresholds

💡 What: Replaced the asymptotic Chi-Square threshold for Mahalanobis distance with the exact scaled Beta distribution for small sample sizes.
🎯 Why: In small samples (N > d + 1 but not $\to \infty$), the squared Mahalanobis distance using the sample covariance matrix is bounded by $(N-1)^2/N$ and follows a scaled Beta distribution. Relying purely on the asymptotic Chi-Square distribution incorrectly trims tails or masks outliers.
📐 Theory: $D^2 \sim \frac{(N-1)^2}{N} \text{Beta}(\frac{d}{2}, \frac{N-d-1}{2})$. If $N \le d+1$, the covariance is rank-deficient/unstable, and we fallback to Chi-Square.
🧪 Validation: Verified correctness using an isolated test script against both dataframe and pure numpy inputs, ensuring both code branches compute valid keep masks. General stats tests also passed.
⚠️ Limits: Still falls back to Chi-Square when $N \le d+1$ because Beta parameters require positive degrees of freedom.

---
*PR created automatically by Jules for task [10098810927292993131](https://jules.google.com/task/10098810927292993131) started by @eigenP*