### PR TITLE
⚡ matth: Exact Mahalanobis Outlier Distribution

### DIFF
--- a/src/eigenp_utils/stats.py
+++ b/src/eigenp_utils/stats.py
@@ -416,7 +416,11 @@ def remove_outliers(data, method='iqr', threshold=1.5, column=None):
                     left = np.dot(X_centered, inv_cov)
                     D_squared = np.sum(left * X_centered, axis=1)
 
-                    chi2_thresh = stats.chi2.ppf(threshold, df=n_features)
+                    if n_samples <= n_features + 1:
+                        chi2_thresh = stats.chi2.ppf(threshold, df=n_features)
+                    else:
+                        beta_thresh = stats.beta.ppf(threshold, n_features / 2.0, (n_samples - n_features - 1) / 2.0)
+                        chi2_thresh = ((n_samples - 1)**2 / n_samples) * beta_thresh
 
                     valid_keep = D_squared <= chi2_thresh
                     bool_mask[valid_row_mask] = valid_keep
@@ -481,7 +485,11 @@ def remove_outliers(data, method='iqr', threshold=1.5, column=None):
                 left = np.dot(X_centered, inv_cov)
                 D_squared = np.sum(left * X_centered, axis=1)
 
-                chi2_thresh = stats.chi2.ppf(threshold, df=n_features)
+                if n_samples <= n_features + 1:
+                    chi2_thresh = stats.chi2.ppf(threshold, df=n_features)
+                else:
+                    beta_thresh = stats.beta.ppf(threshold, n_features / 2.0, (n_samples - n_features - 1) / 2.0)
+                    chi2_thresh = ((n_samples - 1)**2 / n_samples) * beta_thresh
 
                 valid_keep = D_squared <= chi2_thresh
                 keep_mask[valid_row_mask] = valid_keep


### PR DESCRIPTION
💡 What: Modified the threshold computation for multivariate outlier detection in `remove_outliers` (when `method='mahalanobis'`).
🎯 Why: Cascading univariate thresholds implicitly assumes orthogonal feature variance and destroys covariance geometry, while standard $\chi^2$ thresholding for squared Mahalanobis distance is only asymptotically correct, masking extreme outliers in small sample settings.
📐 Theory: The squared Mahalanobis distances derived using the sample mean and sample covariance matrix strictly follow a scaled Beta distribution for finite samples ($D_i^2 \sim \frac{(N-1)^2}{N} \text{Beta}(\frac{p}{2}, \frac{N-p-1}{2})$).
🧪 Validation: Verified correctness by writing exact threshold calculations and ensuring they pass the updated `test_stats.py` validation. Tested robustness on the degenerate condition where $N \le p + 1$.
⚠️ Limits: Degenerate matrices where degrees of freedom prevent fitting exact Beta distributions will fallback correctly to asymptotic $\chi^2$.

---
*PR created automatically by Jules for task [17717873258171016471](https://jules.google.com/task/17717873258171016471) started by @eigenP*