### PR TITLE
Fix channel_labels in interactive ortho viewers

### DIFF
--- a/src/eigenp_utils/tnia_plotting_anywidgets.py
+++ b/src/eigenp_utils/tnia_plotting_anywidgets.py
@@ -2479,7 +2479,7 @@ def show_zyx_max_slice_interactive(
     colors=None, opacity=None,
     slabs_position=None, x_s=None, y_s=None, z_s=None,
     slabs_thickness=None, x_t=None, y_t=None, z_t=None,
-    rotate_view=None,
+    rotate_view=None, channel_labels=None,
 ):
     """
     Interactive 3D slice viewer using AnyWidget.
@@ -2572,7 +2572,7 @@ def show_zyx_max_slice_interactive(
     w = TNIASliceWidget(
         im, pixel_sizes=pixel_sizes, figsize=figsize, colormap=colormap if colormap is not None else colors,
         vmin=vmin, vmax=vmax, gamma=gamma, opacity=opacity, show_crosshair=show_crosshair, sync_on_hover=sync_on_hover,
-        slabs_position=(z_s, y_s, x_s), slabs_thickness=(z_t, y_t, x_t), rotate_view=rotate_view
+        slabs_position=(z_s, y_s, x_s), slabs_thickness=(z_t, y_t, x_t), rotate_view=rotate_view, channel_labels=channel_labels
     )
     return w
 
@@ -2587,7 +2587,7 @@ def show_zyx_max_slice_interactive_point_annotator(
     point_size_scale=0.01,
     slabs_position=None, x_s=None, y_s=None, z_s=None,
     slabs_thickness=None, x_t=None, y_t=None, z_t=None,
-    rotate_view=None,
+    rotate_view=None, channel_labels=None,
 ):
     """
     Interactive 3D slice viewer with point annotation using AnyWidget.
@@ -2673,7 +2673,7 @@ def show_zyx_max_slice_interactive_point_annotator(
         im, pixel_sizes=pixel_sizes, figsize=figsize, colormap=colormap if colormap is not None else colors,
         vmin=vmin, vmax=vmax, gamma=gamma, opacity=opacity, show_crosshair=show_crosshair, sync_on_hover=sync_on_hover,
         point_size_scale=point_size_scale,
-        slabs_position=(z_s, y_s, x_s), slabs_thickness=(z_t, y_t, x_t), rotate_view=rotate_view
+        slabs_position=(z_s, y_s, x_s), slabs_thickness=(z_t, y_t, x_t), rotate_view=rotate_view, channel_labels=channel_labels
     )
     return w
 
@@ -2691,7 +2691,7 @@ def show_zyx_max_scatter_interactive(
     subplot_bg='black',
     slabs_position=None, x_s=None, y_s=None, z_s=None,
     slabs_thickness=None, x_t=None, y_t=None, z_t=None,
-    rotate_view=None,
+    rotate_view=None, channel_labels=None,
 ):
     """
     Shows interactive sliders for XY, XZ, and YZ projection of 3D point coordinates.
@@ -2828,7 +2828,7 @@ def show_zyx_max_scatter_interactive(
         gamma=gamma, vmin=vmin, vmax=vmax, figsize=figsize, show_crosshair=show_crosshair, sync_on_hover=sync_on_hover,
         subplot_bg=subplot_bg,
         slabs_position=(z_s, y_s, x_s), slabs_thickness=(z_t, y_t, x_t),
-        rotate_view=rotate_view
+        rotate_view=rotate_view, channel_labels=channel_labels
     )
     w.X_arr_phys = w.X_arr * px
     w.Y_arr_phys = w.Y_arr * py

--- a/tests/test_tnia_plotting_anywidgets.py
+++ b/tests/test_tnia_plotting_anywidgets.py
@@ -311,3 +311,41 @@ def test_show_zyx_max_slabs_zero_sized_slices():
     assert w.sy == 2.5
     assert w.sx == 3.5
     assert isinstance(w.sz, float)
+
+def test_interactive_channel_labels():
+    from eigenp_utils.tnia_plotting_anywidgets import (
+        show_zyx_max_slice_interactive,
+        show_zyx_max_slice_interactive_point_annotator,
+        show_zyx_max_scatter_interactive
+    )
+    import numpy as np
+
+    im = np.zeros((10, 20, 30))
+    labels = ["DAPI", "GFP"]
+
+    w1 = show_zyx_max_slice_interactive(
+        [im, im],
+        channel_labels=labels
+    )
+    assert w1.channel_labels_input == labels
+    assert w1.channel_names == labels
+
+    w2 = show_zyx_max_slice_interactive_point_annotator(
+        [im, im],
+        channel_labels=labels
+    )
+    assert w2.channel_labels_input == labels
+    assert w2.channel_names == labels + ['Annotations']
+
+    X = np.random.rand(10) * 10
+    Y = np.random.rand(10) * 10
+    Z = np.random.rand(10) * 10
+    channels_multi = [np.random.rand(10), np.random.rand(10)]
+
+    w3 = show_zyx_max_scatter_interactive(
+        (Z, Y, X),
+        channels=channels_multi,
+        channel_labels=labels,
+        render='points'
+    )
+    assert w3.channel_labels_input == labels


### PR DESCRIPTION
Resolves an issue where `show_zyx_max_slice_interactive` threw a `TypeError: unexpected keyword argument 'channel_labels'`. The `channel_labels` argument is now supported in all interactive ortho viewer wrapper functions.

---
*PR created automatically by Jules for task [18222169056598529107](https://jules.google.com/task/18222169056598529107) started by @eigenP*