### PR TITLE
Update channel labels styling in ortho viewers

### DIFF
--- a/src/eigenp_utils/tnia_plotting_anywidgets.py
+++ b/src/eigenp_utils/tnia_plotting_anywidgets.py
@@ -314,22 +314,22 @@ def show_zyx(xy, xz, zy, pixel_sizes=None, sxy=None, sz=None, figsize=(10,10), c
     row2_h = h_xz * z_xy_ratio
 
     if channel_labels is not None:
-        # Calculate label row height, e.g. 10% of main view height
-        label_row_h = max(row1_h * 0.15, 30)
+        # Calculate label row height, e.g. 5% of total figure height
+        label_row_h = max((row1_h + row2_h) * 0.05, 15)
         spec=gridspec.GridSpec(ncols=2, nrows=3,
                                height_ratios=[label_row_h, row1_h, row2_h],
                                width_ratios=[col1_w, col2_w],
                                hspace=.01 * hspace_factor,
                                wspace=.01,
                                figure = fig)
-        axLabels = fig.add_subplot(spec[0, :])
+        axLabels = fig.add_subplot(spec[0, 0])
 
         axXY=fig.add_subplot(spec[1, 0])
         axZY=fig.add_subplot(spec[1, 1])
         axXZ=fig.add_subplot(spec[2, 0])
         axBar=fig.add_subplot(spec[2, 1])
 
-        axLabels.set_facecolor('#eeeeee')
+        axLabels.set_facecolor((0.6, 0.6, 0.6))
         axLabels.set_xticks([])
         axLabels.set_yticks([])
         for spine in axLabels.spines.values():


### PR DESCRIPTION
Updates the styling of the `channel_labels` in the interactive ortho viewers in `tnia_plotting_anywidgets.py` as requested by the user:
1.  **Size Reduction:** The label row height is now calculated to be ~5% of the total figure height instead of 15% of the main view height.
2.  **Width Restriction:** The label axis now only spans the width of the main XY axis instead of the full figure width.
3.  **Background Color:** The background color of the label axis has been changed to gray `(0.6, 0.6, 0.6)`.

---
*PR created automatically by Jules for task [8111585995999818416](https://jules.google.com/task/8111585995999818416) started by @eigenP*