### PR TITLE
Optimize extended depth of focus and add benchmark test

### DIFF
--- a/src/eigenp_utils/extended_depth_of_focus.py
+++ b/src/eigenp_utils/extended_depth_of_focus.py
@@ -6,13 +6,13 @@
 #     "scipy",
 # ]
 # ///
-### extended depth of focus with patch blending
+"""extended depth of focus with patch blending"""
 
 import numpy as np
 import skimage.io
 
-from scipy.ndimage import generic_filter, zoom, laplace, uniform_filter
-
+from scipy.ndimage import laplace, uniform_filter
+from scipy.interpolate import RegularGridInterpolator
 from skimage.filters import median
 from skimage.morphology import disk
 
@@ -27,13 +27,8 @@ def apply_median_filter(height_map):
     Returns:
     ndarray: The filtered 2D array.
     """
-    # Define a 3x3 (radius 1) disk structuring element for the median filter
     selem = disk(1)
-
-    # Apply the median filter with the defined structuring element
-    filtered_map = median(height_map, selem, mode='reflect')
-
-    return filtered_map
+    return median(height_map, selem, mode='reflect')
 
 
 def _get_1d_weight_variants(patch_size, overlap):
@@ -44,11 +39,10 @@ def _get_1d_weight_variants(patch_size, overlap):
     - end: Taper Start, Flat End (Bottom/Right Boundary)
     - flat: Flat Start, Flat End (Single Patch)
     """
-    def weight_1d(x):
-        return 3 * x**2 - 2 * x**3
-
-    x = np.linspace(0, 1, overlap)
-    taper = weight_1d(x).astype(np.float32)
+    x = np.linspace(0, 1, overlap, dtype=np.float32)
+    x2 = x * x
+    x3 = x2 * x
+    taper = (3.0 * x2 - 2.0 * x3).astype(np.float32)
 
     # Base: Flat
     w_base = np.ones(patch_size, dtype=np.float32)
@@ -67,28 +61,30 @@ def _get_1d_weight_variants(patch_size, overlap):
     w_end[:overlap] *= taper
 
     # Flat (Single Patch -> No Taper)
-    w_flat = w_base.copy()
+    w_flat = w_base
 
     return w_full, w_start, w_end, w_flat
 
 
 def _cubic_interp_1d(p0, p1, p2, p3, t):
     """
-    Cubic Hermite spline (Catmull-Rom) interpolation.
-    p0, p1, p2, p3: values at t=-1, 0, 1, 2
-    t: fractional position between p1 and p2 (0 <= t <= 1)
+    Cubic Hermite spline (Catmull-Rom) interpolation evaluated via scalar basis weights.
+    p0, p1, p2, p3: ndarray values at t=-1, 0, 1, 2
+    t: scalar fractional position between p1 and p2 (0 <= t <= 1)
     """
-    return 0.5 * (
-        (2 * p1) +
-        (-p0 + p2) * t +
-        (2 * p0 - 5 * p1 + 4 * p2 - p3) * (t ** 2) +
-        (-p0 + 3 * p1 - 3 * p2 + p3) * (t ** 3)
-    )
+    t2 = t * t
+    t3 = t2 * t
+    c0 = 0.5 * (-t + 2.0 * t2 - t3)
+    c1 = 0.5 * (2.0 - 5.0 * t2 + 3.0 * t3)
+    c2 = 0.5 * (t + 4.0 * t2 - 3.0 * t3)
+    c3 = 0.5 * (-t2 + t3)
+
+    return c0 * p0 + c1 * p1 + c2 * p2 + c3 * p3
 
 
 def _get_fractional_peak(score_matrix):
     """
-    Refines the discrete argmax peak using parabolic interpolation.
+    Refines the discrete argmax peak using parabolic interpolation on log-scores.
 
     score_matrix: (Z, H, W)
 
@@ -96,364 +92,209 @@ def _get_fractional_peak(score_matrix):
     peak_z: (H, W) float32
     """
     Z, H, W = score_matrix.shape
-    idx = np.argmax(score_matrix, axis=0) # (H, W)
+    idx = np.argmax(score_matrix, axis=0)  # (H, W)
 
-    # We need values at idx-1, idx, idx+1
-    # Clamp to ensure we don't access out of bounds
     z_c = idx
     z_l = np.maximum(z_c - 1, 0)
     z_r = np.minimum(z_c + 1, Z - 1)
 
-    # Extract values
-    # Advanced indexing
-    grid_y, grid_x = np.indices((H, W))
-
-    # matth: Use Log-Parabolic Interpolation
-    # Focus metrics (squared Laplacian) often follow a Gaussian-like decay: E ~ exp(-(z-z0)^2).
-    # Fitting a parabola to the raw Gaussian yields biased peak estimates.
-    # Fitting a parabola to log(E) ~ -(z-z0)^2 recovers the peak exactly.
     eps = 1e-12
-    v_c = np.log(score_matrix[z_c, grid_y, grid_x] + eps)
-    v_l = np.log(score_matrix[z_l, grid_y, grid_x] + eps)
-    v_r = np.log(score_matrix[z_r, grid_y, grid_x] + eps)
+    # Extract values along Z using take_along_axis to avoid dense coordinate meshes
+    v_c = np.log(np.take_along_axis(score_matrix, z_c[None, ...], axis=0)[0] + eps)
+    v_l = np.log(np.take_along_axis(score_matrix, z_l[None, ...], axis=0)[0] + eps)
+    v_r = np.log(np.take_along_axis(score_matrix, z_r[None, ...], axis=0)[0] + eps)
 
-    # Parabolic fit on Log scores
-    # Delta = (v_l - v_r) / (2 * (v_l - 2*v_c + v_r))
-    denom = v_l - 2*v_c + v_r
+    denom = v_l - 2.0 * v_c + v_r
 
-    # Handle denominator close to zero (flat or linear)
-    # v_c is max, so denom is <= 0.
     delta = np.zeros_like(v_c, dtype=np.float32)
-    mask = np.abs(denom) > 1e-9
+    # Only refine valid non-flat interiors away from Z boundaries
+    valid = (np.abs(denom) > 1e-9) & (idx > 0) & (idx < Z - 1)
+    delta[valid] = (v_l[valid] - v_r[valid]) / (2.0 * denom[valid])
 
-    # We expect negative denominator for a maximum
-    delta[mask] = (v_l[mask] - v_r[mask]) / (2 * denom[mask])
-
-    # Clamp delta to [-0.5, 0.5] to prevent instability
-    # Also clamp to 0 if we are at the boundaries of the stack
-    boundary_mask = (idx == 0) | (idx == Z - 1)
-    delta[boundary_mask] = 0
-
-    delta = np.clip(delta, -0.5, 0.5)
+    np.clip(delta, -0.5, 0.5, out=delta)
 
     return idx.astype(np.float32) + delta
 
 
-def best_focus_image(image_or_path, patch_size=None, return_heightmap=False, test = None):
-    '''
-    Expecting an image with dimension order ZYX
-    If you have a timelapse, please pass in each individual frame
-    e.g. you can slice as frame_img = time_lapse_img[t, ...]
-    '''
+def best_focus_image(image_or_path, patch_size=None, return_heightmap=False, test=None):
+    """
+    Extended depth of focus via local focus scoring and weighted subpixel patch blending.
+    Dimension order expected: ZYX
+    """
     # 1. Load the image
     if isinstance(image_or_path, str):
         img = skimage.io.imread(image_or_path)
     else:
         img = image_or_path
-    
-    # 1.1 Validate ndim
+
     if img.ndim != 3:
         raise ValueError(f'Image not 3D, instead received {img.ndim} dims')
 
     original_shape = img.shape[1:]
+    H, W = original_shape
 
-    # 2. Determine the patch size and pad the image to fit
+    # 2. Determine patch size and padding
     if patch_size is None:
         patch_size = min(original_shape) // 10
-    # overlap = patch_size // 4  # 25% overlap
     overlap = patch_size // 3  # 33% overlap
 
-    # Fix: padding should be based on Y and X dimensions (shape[1] and shape[2]), not Z (shape[0])
-    pad_y = (patch_size - img.shape[1] % patch_size) + overlap
-    pad_x = (patch_size - img.shape[2] % patch_size) + overlap
+    pad_y = (patch_size - H % patch_size) + overlap
+    pad_x = (patch_size - W % patch_size) + overlap
 
-    # bolt: Removed full 3D padding (img_padded) to save O(Z*H*W) memory.
-    # Instead, we apply padding on the fly per slice (scoring) or per patch (reconstruction).
-    # This reduces peak memory significantly (e.g. from 1.6GB to ~200MB for typical stacks).
+    padded_H = H + pad_y
+    padded_W = W + pad_x
 
-    # Virtual dimensions of the padded space
-    padded_H = img.shape[1] + pad_y
-    padded_W = img.shape[2] + pad_x
-
-    # 3. Calculate Focus Metric Vectorized
-    # Metric: Laplacian Energy (Sum of Squared Laplacian)
-    # Optimization: Use float32 to reduce memory usage by 50% compared to float64.
-
-    # Grid dimensions
     n_patches_y = padded_H // (patch_size - overlap)
     n_patches_x = padded_W // (patch_size - overlap)
 
-    # Initialize score matrix: (Z, rows, cols)
+    max_y_end = (n_patches_y - 1) * (patch_size - overlap) + patch_size
+    max_x_end = (n_patches_x - 1) * (patch_size - overlap) + patch_size
+
+    pad_y_needed = max(pad_y, max_y_end - H)
+    pad_x_needed = max(pad_x, max_x_end - W)
+
+    padded_H = H + pad_y_needed
+    padded_W = W + pad_x_needed
+
+    # 3. Calculate Focus Metric Vectorized
     score_matrix = np.zeros((img.shape[0], n_patches_y, n_patches_x), dtype=np.float32)
 
-    # Grid coordinates (centers of patches) for sampling
     y_starts = np.arange(n_patches_y) * (patch_size - overlap)
     x_starts = np.arange(n_patches_x) * (patch_size - overlap)
 
     y_centers = y_starts + patch_size // 2
     x_centers = x_starts + patch_size // 2
 
-    # Pre-allocate buffers to reuse memory across Z-slices
-    # Reduces allocation churn and runtime overhead significantly
-    # padded_buffer stores the padded input slice
-    # lap_buffer stores the laplacian (float32)
-    # energy_buffer stores the uniform filter result (float32)
+    # Pre-index mesh outside the slice loop to eliminate redundant allocations
+    sample_idx = np.ix_(y_centers, x_centers)
 
-    # Check if manual padding is safe (pad < dim - 1)
-    # If pad is too large, manual slice logic fails, so fallback to np.pad
-    H, W = img.shape[1], img.shape[2]
-    use_fast_pad = (pad_y < H - 1) and (pad_x < W - 1)
+    use_fast_pad = (pad_y_needed < H - 1) and (pad_x_needed < W - 1)
 
     padded_buffer = np.zeros((padded_H, padded_W), dtype=img.dtype)
     lap_buffer = np.zeros((padded_H, padded_W), dtype=np.float32)
     energy_buffer = np.zeros((padded_H, padded_W), dtype=np.float32)
 
-    # Iterate over Z-slices one by one to keep memory usage low
     for z in range(img.shape[0]):
-        # 1. Pad only the current slice (2D)
-        # This keeps memory overhead to O(H*W) instead of O(Z*H*W)
-
         if use_fast_pad:
-            # Copy core
             padded_buffer[:H, :W] = img[z]
-
-            # Reflect Right (approx, ensuring dims match)
-            # Reflect H rows, pad_x cols
-            # input: img[:H, W-pad_x-1:W-1][:, ::-1] -> shape (H, pad_x)
-            padded_buffer[:H, W:] = img[z][:, -pad_x-1:-1][:, ::-1]
-
-            # Reflect Bottom (approx)
-            # Reflect pad_y rows, all cols (including already padded right side)
-            # input: padded_buffer[H-pad_y-1:H-1, :][::-1, :] -> shape (pad_y, W+pad_x)
-            padded_buffer[H:, :] = padded_buffer[H-pad_y-1:H-1, :][::-1, :]
-
-            slice_padded = padded_buffer # Reference, no copy
+            padded_buffer[:H, W:] = img[z][:, -pad_x_needed-1:-1][:, ::-1]
+            padded_buffer[H:, :] = padded_buffer[H-pad_y_needed-1:H-1, :][::-1, :]
+            slice_padded = padded_buffer
         else:
-            # Fallback for large pads
-            slice_padded = np.pad(img[z], ((0, pad_y), (0, pad_x)), mode='reflect')
+            slice_padded = np.pad(img[z], ((0, pad_y_needed), (0, pad_x_needed)), mode='reflect')
 
-        # 2. Compute Laplacian directly into reusable float32 buffer
-        # 'output=lap_buffer' reuses memory
         laplace(slice_padded, output=lap_buffer)
-
-        # 3. Compute Energy (Squared) in-place
         np.square(lap_buffer, out=lap_buffer)
-
-        # 4. Local Average Energy (proxy for sum over patch)
-        # Reuses energy_buffer
         uniform_filter(lap_buffer, size=patch_size, output=energy_buffer, mode='reflect')
 
-        # 5. Sample at patch centers
-        score_matrix[z] = energy_buffer[np.ix_(y_centers, x_centers)]
-
-        # Explicit delete not needed as buffers are reused, but slice_padded might be a new array in fallback
-        if not use_fast_pad:
-             del slice_padded
+        score_matrix[z] = energy_buffer[sample_idx]
 
     # 4. Select best Z with Subpixel Precision
-    # matth: Use parabolic interpolation to find fractional peak
     height_map_small = _get_fractional_peak(score_matrix)
-
-    # Apply median filter (works on floats, preserves edges while removing outliers)
     height_map_small = apply_median_filter(height_map_small)
 
     # 5. Combine patches to create the final image
-    # Use float32 for accumulation to save memory
     final_img = np.zeros((padded_H, padded_W), dtype=np.float32)
-    counts = np.zeros((padded_H, padded_W), dtype=np.float32) # matth: Restored counts
+    counts = np.zeros((padded_H, padded_W), dtype=np.float32)
 
-    # Precompute 1D weight variants to handle boundaries
-    wy_full, wy_start, wy_end, wy_flat = _get_1d_weight_variants(patch_size, overlap)
-    wx_full, wx_start, wx_end, wx_flat = _get_1d_weight_variants(patch_size, overlap)
+    # Precompute unique 1D weight variants and unique 2D blending windows
+    w_variants = _get_1d_weight_variants(patch_size, overlap)  # (full, start, end, flat)
 
-    n_patches_y = height_map_small.shape[0]
-    n_patches_x = height_map_small.shape[1]
+    def _get_weight_type(idx, total):
+        if total == 1:
+            return 3  # flat
+        if idx == 0:
+            return 1  # start
+        if idx == total - 1:
+            return 2  # end
+        return 0      # full
+
+    # Cache unique 2D window arrays (max 9 combinations)
+    unique_windows = {}
+    for wy_t in range(4):
+        for wx_t in range(4):
+            unique_windows[(wy_t, wx_t)] = w_variants[wy_t][:, None] * w_variants[wx_t][None, :]
+
+    window_grid = [
+        [unique_windows[(_get_weight_type(i, n_patches_y), _get_weight_type(j, n_patches_x))]
+         for j in range(n_patches_x)]
+        for i in range(n_patches_y)
+    ]
 
     Z_dim = img.shape[0]
 
-    # Helper to extract a padded patch from a specific Z slice
-    def _get_padded_patch(z_idx, y_s, x_s, y_e, x_e, y_start, x_start):
-        # Determine safe extraction bounds from original image
-        y_s_clamped = y_s
-        y_e_clamped = min(y_e, img.shape[1])
-        pad_bottom = 0
+    # Fast patch extraction
+    def _get_padded_patch(z_idx, y_start, x_start):
+        y_end = y_start + patch_size
+        x_end = x_start + patch_size
 
-        if y_e > img.shape[1]:
-            pad_bottom = pad_y
-            needed_history = max(pad_bottom + 1, y_e - img.shape[1] + 2)
-            y_s_clamped = min(y_s_clamped, img.shape[1] - needed_history)
-            y_s_clamped = max(0, y_s_clamped)
-            y_e_clamped = img.shape[1]
+        # Fast path: strictly interior patch requiring no boundary reflection
+        if y_end <= H and x_end <= W:
+            return img[z_idx, y_start:y_end, x_start:x_end].astype(np.float32)
 
-        x_s_clamped = x_s
-        x_e_clamped = min(x_e, img.shape[2])
-        pad_right = 0
+        # Boundary path
+        return np.pad(img[z_idx], ((0, pad_y_needed), (0, pad_x_needed)), mode='reflect')[y_start:y_end, x_start:x_end].astype(np.float32)
 
-        if x_e > img.shape[2]:
-            pad_right = pad_x
-            needed_history = max(pad_right + 1, x_e - img.shape[2] + 2)
-            x_s_clamped = min(x_s_clamped, img.shape[2] - needed_history)
-            x_s_clamped = max(0, x_s_clamped)
-            x_e_clamped = img.shape[2]
-
-        # Extract chunk
-        chunk = img[z_idx, y_s_clamped:y_e_clamped, x_s_clamped:x_e_clamped]
-
-        # Pad chunk locally
-        if pad_bottom > 0 or pad_right > 0:
-            chunk_padded = np.pad(chunk, ((0, pad_bottom), (0, pad_right)), mode='reflect')
-        else:
-            chunk_padded = chunk
-
-        # Slice out the exact target region relative to chunk start
-        y_rel = y_start - y_s_clamped
-        x_rel = x_start - x_s_clamped
-
-        return chunk_padded[y_rel : y_rel + patch_size, x_rel : x_rel + patch_size].astype(np.float32)
-
-
+    # Main patch reconstruction loop
     for i in range(n_patches_y):
-        # Select Y-weight
-        if n_patches_y == 1:
-            wy = wy_flat
-        elif i == 0:
-            wy = wy_start
-        elif i == n_patches_y - 1:
-            wy = wy_end
-        else:
-            wy = wy_full
+        y_start = i * (patch_size - overlap)
+        y_end = y_start + patch_size
 
         for j in range(n_patches_x):
-            # Select X-weight
-            if n_patches_x == 1:
-                wx = wx_flat
-            elif j == 0:
-                wx = wx_start
-            elif j == n_patches_x - 1:
-                wx = wx_end
-            else:
-                wx = wx_full
-
-            # Construct 2D window on the fly
-            _2D_window = wy[:, None] * wx[None, :]
-
-            y_start = i * (patch_size - overlap)
             x_start = j * (patch_size - overlap)
-            best_z = height_map_small[i, j]
-
-            # Patch bounds
-            y_end = y_start + patch_size
             x_end = x_start + patch_size
 
-            # matth: Subpixel reconstruction
-            # Use Cubic (Catmull-Rom) interpolation to preserve high-frequency content (contrast)
-            # Linear interpolation acts as a low-pass filter, degrading the sharpness gained by subpixel depth estimation.
+            _2D_window = window_grid[i][j]
+            best_z = height_map_small[i, j]
 
             z_floor = int(np.floor(best_z))
-            alpha = best_z - z_floor
+            alpha = float(best_z - z_floor)
 
-            # Clamp indices for 4-point stencil
             z0 = max(0, min(z_floor - 1, Z_dim - 1))
             z1 = max(0, min(z_floor, Z_dim - 1))
             z2 = max(0, min(z_floor + 1, Z_dim - 1))
             z3 = max(0, min(z_floor + 2, Z_dim - 1))
 
-            # Fetch patches
-            # Optimization: If integer coordinates, skip interpolation
-            if z1 == z2:  # z_floor == z_ceil implies alpha=0
-                patch = _get_padded_patch(z1, y_start, x_start, y_end, x_end, y_start, x_start)
+            if z1 == z2:
+                patch = _get_padded_patch(z1, y_start, x_start)
             else:
-                p1 = _get_padded_patch(z1, y_start, x_start, y_end, x_end, y_start, x_start)
-                p2 = _get_padded_patch(z2, y_start, x_start, y_end, x_end, y_start, x_start)
-
-                # Fetch extra points for cubic spline
-                # If at boundaries, clamp (duplicate nearest neighbor)
-                # This corresponds to "natural" or "clamped" spline behavior at edges
-                if z0 == z1:
-                    p0 = p1
-                else:
-                    p0 = _get_padded_patch(z0, y_start, x_start, y_end, x_end, y_start, x_start)
-
-                if z3 == z2:
-                    p3 = p2
-                else:
-                    p3 = _get_padded_patch(z3, y_start, x_start, y_end, x_end, y_start, x_start)
+                p1 = _get_padded_patch(z1, y_start, x_start)
+                p2 = _get_padded_patch(z2, y_start, x_start)
+                p0 = p1 if z0 == z1 else _get_padded_patch(z0, y_start, x_start)
+                p3 = p2 if z3 == z2 else _get_padded_patch(z3, y_start, x_start)
 
                 patch = _cubic_interp_1d(p0, p1, p2, p3, alpha)
-                # matth: Clamp negative values that may arise from cubic undershoot (ringing)
-                np.maximum(patch, 0, out=patch)
+                np.maximum(patch, 0.0, out=patch)
 
-            # Create weighted patch
-            try:
-                # weighted_patch = patch * _2D_window
-                # In-place multiplication
-                np.multiply(patch, _2D_window, out=patch)
-                weight_matrix = _2D_window
-            except ValueError:
-                # Boundary case
-                min_shape = tuple(min(s1, s2) for s1, s2 in zip(patch.shape, _2D_window.shape))
-                patch = patch * _2D_window[:min_shape[0], :min_shape[1]]
-                weight_matrix = _2D_window[:min_shape[0], :min_shape[1]]
+            # In-place patch weighting
+            patch *= _2D_window
 
-            # Add to accumulators
-            final_img[y_start:y_start+patch_size, x_start:x_start+patch_size] += patch
-            counts[y_start:y_start+patch_size, x_start:x_start+patch_size] += weight_matrix
+            final_img[y_start:y_end, x_start:x_end] += patch
+            counts[y_start:y_end, x_start:x_end] += _2D_window
 
-    # Normalize by the weight counts
-    # Avoid division by zero
+    # Normalize by accumulated weights
     counts[counts < 1e-9] = 1.0
-    # In-place division
-    np.divide(final_img, counts, out=final_img)
+    final_img /= counts
 
-    # 6. Recrop
-    final_img = final_img[:original_shape[0], :original_shape[1]]
+    # 6. Recrop to original shape
+    final_img = final_img[:H, :W]
 
     if return_heightmap:
-        # matth: Use RegularGridInterpolator for spatially accurate upscaling
-        # scipy.ndimage.zoom assumes a different coordinate system that introduces
-        # a systematic shift. We map the exact patch centers to the pixel grid.
-        from scipy.interpolate import RegularGridInterpolator
+        y_c = (y_starts + patch_size // 2).astype(np.float32)
+        x_c = (x_starts + patch_size // 2).astype(np.float32)
 
-        n_patches_y = height_map_small.shape[0]
-        n_patches_x = height_map_small.shape[1]
-
-        # Coordinates of the centers where height_map_small is defined
-        # Note: In scoring, y_centers = y_starts + patch_size // 2
-        # y_starts = i * (patch_size - overlap)
-        y_starts = np.arange(n_patches_y) * (patch_size - overlap)
-        x_starts = np.arange(n_patches_x) * (patch_size - overlap)
-
-        y_c = y_starts + patch_size // 2
-        x_c = x_starts + patch_size // 2
-
-        # Create interpolator
-        # bounds_error=False, fill_value=None -> Linear extrapolation
         interp = RegularGridInterpolator((y_c, x_c), height_map_small, bounds_error=False, fill_value=None)
 
-        # Target grid coordinates
-        gy = np.arange(original_shape[0])
-        gx = np.arange(original_shape[1])
+        gy = np.arange(H, dtype=np.float32)
+        gx = np.arange(W, dtype=np.float32)
 
-        # Meshgrid for interpolation (indexing='ij')
-        # We can optimize by broadcasting if grid is huge, but RegularGridInterpolator
-        # usually expects (N, 2) points or tuple of grids.
-        # interp((gy[:, None], gx[None, :])) works if grid is tuple?
-        # No, RegularGridInterpolator.__call__ expects points (N, D) or (y, x) if method='linear'.
-        # Actually it supports meshgrid style inputs in newer scipy.
-        # Let's use the explicit meshgrid to be safe and clear.
-        GY, GX = np.meshgrid(gy, gx, indexing='ij')
-
-        # Flatten for interpolation then reshape, or pass directly if supported.
-        # Passing tuple (GY, GX) is supported in SciPy 1.9+.
-        # We'll assume a reasonably modern SciPy.
         try:
-            height_map_full = interp((GY, GX))
+            # SciPy 1.9+ broadcastable open grid evaluation
+            height_map_full = interp((gy[:, None], gx[None, :])).astype(np.float32)
         except (TypeError, ValueError):
-            # Fallback for older SciPy
+            GY, GX = np.meshgrid(gy, gx, indexing='ij')
             pts = np.array([GY.ravel(), GX.ravel()]).T
-            height_map_full = interp(pts).reshape(original_shape)
-
-        height_map_full = height_map_full.astype(np.float32)
+            height_map_full = interp(pts).reshape(original_shape).astype(np.float32)
 
         return final_img, height_map_full
 

--- a/tests/test_extended_depth_of_focus.py
+++ b/tests/test_extended_depth_of_focus.py
@@ -7,7 +7,6 @@ import unittest
 from eigenp_utils.extended_depth_of_focus import best_focus_image
 
 
-
 # =========================================
 # Source: test_depth_of_focus_subpixel.py
 # =========================================
@@ -122,8 +121,6 @@ class TestDepthOfFocusSubpixel(unittest.TestCase):
         # but regular grid interpolation should handle it well.
         self.assertLess(rmse, 0.20, f"Slanted plane RMSE {rmse} is too high (expected < 0.20)")
 
-if __name__ == "__main__":
-    unittest.main()
 
 # =========================================
 # Source: test_focus_properties.py
@@ -214,8 +211,6 @@ class TestFocusProperties(unittest.TestCase):
         self.assertLess(max_diff, 0.1,
             "Ramp reconstruction failed. Partition of Unity violated?")
 
-if __name__ == '__main__':
-    unittest.main()
 
 # =========================================
 # Source: test_edof_interpolation.py
@@ -240,62 +235,29 @@ def test_interpolation_quality():
     true_peak_z = 2.5
     sigma_z = 1.0
 
-    # Create a texture (e.g. a bright spot)
-    # For simplicity, just a uniform plane that varies in Z
-    # Or a single pixel to check impulse response?
-    # Let's use a small Gaussian spot in XY as well to ensure it's "focused"
     y, x = np.ogrid[:ny, :nx]
     cy, cx = ny//2, nx//2
     sigma_xy = 5.0
     xy_profile = np.exp(-((y-cy)**2 + (x-cx)**2) / (2 * sigma_xy**2))
 
     for z in range(nz):
-        # Gaussian intensity profile in Z
-        # Note: In real EDOF, "focus" means sharpness (gradient), not just intensity.
-        # But best_focus_image reconstructs the PIXEL VALUE.
-        # If the pixel value varies with Z (as it does in focus), we want to recover the value at best_z.
-        # For a fluorescent bead, intensity is max at focus.
         intensity_factor = np.exp(-(z - true_peak_z)**2 / (2 * sigma_z**2))
         stack[z] = xy_profile * intensity_factor
 
-    # 2. Run best_focus_image
-    # We force the patch size to be large so we essentially treat it as one block
-    # to avoid patch boundary artifacts complicating the measurement.
-    # However, best_focus_image calculates focus metric.
-    # For a pure intensity gaussian, the "sharpness" (Laplacian) is also max at the peak intensity
-    # because Laplacian of Gaussian ~ Gaussian (roughly, second derivative).
-    # d2/dx2 (exp(-x^2)) = (4x^2 - 2) exp(-x^2). The envelope is still Gaussian-ish.
-
     result = best_focus_image(stack, patch_size=32)
-
-    # 3. Measure Peak Intensity
-    # The true peak intensity at (cy, cx) should be 1.0 * 1.0 = 1.0 (at z=2.5)
-    # At z=2 and z=3, intensity is exp(-0.5^2/2) = exp(-0.125) = 0.882
-    # Linear interp: (0.882 + 0.882) / 2 = 0.882.
-    # We expect the result to be significantly higher than 0.882 if cubic is used.
 
     reconstructed_peak = result[cy, cx]
 
     print(f"Reconstructed Peak: {reconstructed_peak:.4f}")
 
-    # Theoretical limits
     val_at_node = np.exp(-(0.5)**2 / 2) # 0.882
     print(f"Value at nodes (z=2,3): {val_at_node:.4f}")
     print(f"True Peak: 1.0000")
 
-    # For linear, it should be close to 0.882
-    # For cubic, it should be > 0.95 maybe?
-
-    # Check if we are doing better than linear
-    # We set a threshold halfway between linear and perfect
-    # Linear is approx 0.8825. 0.94 is a safe threshold for cubic (0.9522).
     threshold = 0.94
 
-    assert reconstructed_peak > threshold, f"Reconstruction {reconstructed_peak:.4f} is too low (Linear behavior?). Expected > {threshold:.4f}"
+    assert reconstructed_peak > threshold, f"Reconstruction {reconstructed_peak:.4f} is too low. Expected > {threshold:.4f}"
 
-
-if __name__ == "__main__":
-    test_interpolation_quality()
 
 # =========================================
 # Source: test_depth_of_focus.py
@@ -308,23 +270,6 @@ def test_best_focus_checkerboard_reconstruction():
 
     This test verifies that the `best_focus_image` algorithm correctly identifies and reconstructs
     regions of focus from a 3D stack.
-
-    The Setup:
-    - We create a "perfect" sharp texture (white noise).
-    - We create a "blurred" version (Gaussian blur).
-    - We construct a 2-slice stack where the focus plane follows a 2x2 checkerboard pattern.
-      - Quadrant 1 (Top-Left):  Slice 0 is Sharp
-      - Quadrant 2 (Top-Right): Slice 1 is Sharp
-      - Quadrant 3 (Bot-Left):  Slice 1 is Sharp
-      - Quadrant 4 (Bot-Right): Slice 0 is Sharp
-
-    The Invariants:
-    1. Focus Map Accuracy: The algorithm must recover a height map (index map) that matches
-       the checkerboard pattern (0s and 1s in correct quadrants), ignoring boundary effects.
-    2. Signal Preservation: The output image must closely resemble the sharp texture (low MSE)
-       and be significantly different from the blurred texture.
-    3. Contrast Conservation: The standard deviation of the output should match the input signal,
-       proving that the blending didn't wash out features.
     """
 
     # 1. Setup Parameters
@@ -333,25 +278,20 @@ def test_best_focus_checkerboard_reconstruction():
     np.random.seed(42)
 
     # 2. Generate Textures
-    # Signal scale 100.0 to make errors obvious
-    # Using random noise ensures high Laplacian energy
     sharp_texture = np.random.uniform(0, 100, (H, W)).astype(np.float32)
     blurred_texture = ndi.gaussian_filter(sharp_texture, sigma=5.0)
 
     # 3. Construct Checkerboard Stack
-    # Slices
     slice0 = np.zeros((H, W), dtype=np.float32)
     slice1 = np.zeros((H, W), dtype=np.float32)
 
     mid_y, mid_x = H // 2, W // 2
 
-    # Slice 0: Sharp in TL, BR. Blurred in TR, BL.
     slice0[:mid_y, :mid_x] = sharp_texture[:mid_y, :mid_x] # TL
     slice0[mid_y:, mid_x:] = sharp_texture[mid_y:, mid_x:] # BR
     slice0[:mid_y, mid_x:] = blurred_texture[:mid_y, mid_x:] # TR
     slice0[mid_y:, :mid_x] = blurred_texture[mid_y:, :mid_x] # BL
 
-    # Slice 1: Blurred in TL, BR. Sharp in TR, BL.
     slice1[:mid_y, :mid_x] = blurred_texture[:mid_y, :mid_x] # TL
     slice1[mid_y:, mid_x:] = blurred_texture[mid_y:, mid_x:] # BR
     slice1[:mid_y, mid_x:] = sharp_texture[:mid_y, mid_x:] # TR
@@ -359,36 +299,20 @@ def test_best_focus_checkerboard_reconstruction():
 
     stack = np.array([slice0, slice1])
 
-    # 4. Run Algorithm
-    # Note: We expect the algorithm to pick the sharpest texture in each patch.
     result_img, height_map = best_focus_image(stack, patch_size=patch_size, return_heightmap=True)
 
-    # 5. Verify Focus Map (Indices)
-    # We sample the center of each quadrant to avoid patch boundary artifacts
-    margin = patch_size  # Stay away from edges and center cross
+    margin = patch_size
 
-    # Quadrant Centers
-    tl_idx = height_map[mid_y//2, mid_x//2]
-    tr_idx = height_map[mid_y//2, mid_x + mid_x//2]
-    bl_idx = height_map[mid_y + mid_y//2, mid_x//2]
-    br_idx = height_map[mid_y + mid_y//2, mid_x + mid_x//2]
-
-    # Also check average over a region in the quadrant to be robust
     tl_region = height_map[margin : mid_y-margin, margin : mid_x-margin]
     tr_region = height_map[margin : mid_y-margin, mid_x+margin : W-margin]
 
     print(f"TL Mean Index: {tl_region.mean():.4f} (Expected 0)")
     print(f"TR Mean Index: {tr_region.mean():.4f} (Expected 1)")
 
-    # Assertions
     assert tl_region.mean() < 0.1, "Top-Left quadrant should be mostly index 0 (Sharp in Slice 0)"
     assert tr_region.mean() > 0.9, "Top-Right quadrant should be mostly index 1 (Sharp in Slice 1)"
 
-    # 6. Verify Reconstruction Quality (MSE)
-    # Compare output to the "Perfect Composite" (which is just sharp_texture everywhere)
-    # We exclude the boundaries (cross in the middle) from the stats calculation
     mask = np.ones((H, W), dtype=bool)
-    # Mask out the center cross seam (width approx 2 patches)
     mask[mid_y-patch_size:mid_y+patch_size, :] = False
     mask[:, mid_x-patch_size:mid_x+patch_size] = False
 
@@ -398,19 +322,14 @@ def test_best_focus_checkerboard_reconstruction():
     print(f"MSE vs Perfect: {mse_perfect:.4f}")
     print(f"MSE vs Blurred: {mse_blurred:.4f}")
 
-    # The reconstruction should be MUCH closer to perfect than to blurred
-    # Typically < 1% of the blurred error
     assert mse_perfect < 0.05 * mse_blurred, \
         f"Reconstruction failed to recover sharp texture. MSE_perfect={mse_perfect}, MSE_blurred={mse_blurred}"
 
-    # 7. Verify Contrast Preservation (Standard Deviation)
-    # Blending can sometimes lower contrast. We want to ensure we kept the signal.
     std_input = np.std(sharp_texture[mask])
     std_output = np.std(result_img[mask])
 
     print(f"Input Std: {std_input:.4f}, Output Std: {std_output:.4f}")
 
-    # Allow small drop due to potential blending/interpolation, but should be close
     assert std_output > 0.95 * std_input, \
         f"Output lost significant contrast. InStd={std_input}, OutStd={std_output}"
 
@@ -450,37 +369,29 @@ def generate_feature_stack(shape=(10, 200, 200), feature_size=60):
 
     return stack, depth_map
 
+
 def test_feature_preservation():
     """
     Verifies that best_focus_image preserves features of moderate size.
     A feature of size 60x60 in a 200x200 image corresponds to approx 4x4 patches (grid 14x14).
-    A 7x7 median filter (disk(3)) would erase this feature (16 pixels < 25 threshold).
     A 3x3 median filter (disk(1)) should preserve it.
     """
     stack, truth_map = generate_feature_stack(shape=(10, 200, 200), feature_size=60)
 
-    # Run reconstruction
     fused, height_map = best_focus_image(stack, return_heightmap=True)
 
-    # Check if the feature is preserved.
-    # We check the max depth value in the center region.
     mid_h, mid_w = 100, 100
-    # Average depth in the feature center
     center_depth = np.mean(height_map[mid_h-10:mid_h+10, mid_w-10:mid_w+10])
 
     print(f"Center Depth: {center_depth:.2f} (Expected ~7)")
 
-    # If erased, center_depth would be close to 2.
-    # If preserved, center_depth should be close to 7.
-
     assert center_depth > 5.0, \
         f"Feature erased! Center depth {center_depth:.2f} is too close to background (2). Over-smoothing detected."
 
-    # Also check MSE globally
     mse = np.mean((height_map - truth_map)**2)
     print(f"MSE: {mse:.4f}")
-    # MSE should be reasonable
     assert mse < 4.0
+
 
 def test_focal_plane_indices():
     """
@@ -491,3 +402,106 @@ def test_focal_plane_indices():
 
     assert height_map.min() >= 0
     assert height_map.max() < 5
+
+
+def generate_synthetic_focal_stack(sharp_image, num_slices=25, k_defocus=0.8):
+    """
+    Generates a synthetic 3D focal stack from a 2D sharp texture using a smooth ground-truth depth surface z_GT(y, x).
+    """
+    H, W = sharp_image.shape
+    y, x = np.mgrid[0:H, 0:W]
+
+    z_mid = num_slices / 2.0
+    z_gt = (
+        z_mid
+        + 0.35 * z_mid * np.sin(2.0 * np.pi * y / H)
+        + 0.25 * z_mid * np.cos(2.0 * np.pi * x / W)
+    ).astype(np.float32)
+
+    max_sigma = k_defocus * num_slices
+    sigma_steps = np.linspace(0, max_sigma, 35)
+    blurred_levels = [gaussian_filter(sharp_image, sigma=s) for s in sigma_steps]
+
+    focal_stack = np.zeros((num_slices, H, W), dtype=np.float32)
+
+    for z in range(num_slices):
+        dist = np.abs(z - z_gt)
+        level_idx = np.clip((dist / max_sigma * (len(sigma_steps) - 1)).astype(int), 0, len(sigma_steps) - 1)
+
+        slice_z = np.zeros((H, W), dtype=np.float32)
+        for idx in np.unique(level_idx):
+            mask = level_idx == idx
+            slice_z[mask] = blurred_levels[idx][mask]
+
+        noise = np.random.normal(0, 0.005, (H, W)).astype(np.float32)
+        focal_stack[z] = np.clip(slice_z + noise, 0.0, 1.0)
+
+    return focal_stack, z_gt
+
+
+def test_synthetic_focal_stack_reconstruction():
+    """
+    Verifies that best_focus_image accurately recovers depth map and focused texture
+    on a synthetic focal stack with a spatially varying ground-truth depth field.
+
+    Invariants and Metrics asserted:
+    1. Height map MAE relative to ground truth depth map z_gt is < 1.5 slices.
+    2. Reconstructed image PSNR and SSIM exceed both Maximum Intensity Projection (MIP)
+       and Mean baselines.
+    """
+    from skimage.metrics import peak_signal_noise_ratio as psnr
+    from skimage.metrics import structural_similarity as ssim
+
+    np.random.seed(42)
+    H, W = 256, 256
+    y, x = np.mgrid[0:H, 0:W]
+    base_texture = np.zeros((H, W), dtype=np.float32)
+    for _ in range(60):
+        cy, cx = np.random.uniform(20, H - 20), np.random.uniform(20, W - 20)
+        rad = np.random.uniform(5, 15)
+        base_texture += np.exp(-((y - cy)**2 + (x - cx)**2) / (2 * rad**2))
+
+    rng = np.random.default_rng(42)
+    speckle = rng.uniform(0.2, 1.0, (H, W)).astype(np.float32)
+    base_texture = base_texture * speckle
+    base_texture = (base_texture - base_texture.min()) / (base_texture.max() - base_texture.min() + 1e-8)
+
+    num_slices = 25
+    focal_stack, z_gt = generate_synthetic_focal_stack(base_texture, num_slices=num_slices)
+
+    patch_size = 32
+    reconstructed_img, estimated_heightmap = best_focus_image(
+        focal_stack, patch_size=patch_size, return_heightmap=True
+    )
+
+    mip_baseline = np.max(focal_stack, axis=0)
+    mean_baseline = np.mean(focal_stack, axis=0)
+
+    valid_crop = np.s_[patch_size:-patch_size, patch_size:-patch_size]
+
+    z_error = np.abs(estimated_heightmap[valid_crop] - z_gt[valid_crop])
+    mae_z = np.mean(z_error)
+
+    psnr_edf = psnr(base_texture[valid_crop], reconstructed_img[valid_crop], data_range=1.0)
+    ssim_edf = ssim(base_texture[valid_crop], reconstructed_img[valid_crop], data_range=1.0)
+
+    psnr_mip = psnr(base_texture[valid_crop], mip_baseline[valid_crop], data_range=1.0)
+    ssim_mip = ssim(base_texture[valid_crop], mip_baseline[valid_crop], data_range=1.0)
+
+    psnr_mean = psnr(base_texture[valid_crop], mean_baseline[valid_crop], data_range=1.0)
+    ssim_mean = ssim(base_texture[valid_crop], mean_baseline[valid_crop], data_range=1.0)
+
+    print(f"Height map MAE: {mae_z:.4f}")
+    print(f"EDF PSNR: {psnr_edf:.2f} dB, SSIM: {ssim_edf:.4f}")
+    print(f"MIP PSNR: {psnr_mip:.2f} dB, SSIM: {ssim_mip:.4f}")
+    print(f"Mean PSNR: {psnr_mean:.2f} dB, SSIM: {ssim_mean:.4f}")
+
+    assert mae_z < 1.5, f"MAE Z error {mae_z:.4f} exceeds 1.5 slices"
+    assert psnr_edf > psnr_mip, f"EDF PSNR ({psnr_edf:.2f}) failed to beat MIP ({psnr_mip:.2f})"
+    assert psnr_edf > psnr_mean, f"EDF PSNR ({psnr_edf:.2f}) failed to beat Mean ({psnr_mean:.2f})"
+    assert ssim_edf > ssim_mip, f"EDF SSIM ({ssim_edf:.4f}) failed to beat MIP ({ssim_mip:.4f})"
+    assert ssim_edf > ssim_mean, f"EDF SSIM ({ssim_edf:.4f}) failed to beat Mean ({ssim_mean:.4f})"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Optimized `best_focus_image` in `src/eigenp_utils/extended_depth_of_focus.py` by evaluating Catmull-Rom basis weights as scalars, precalculating unique 2D blending windows, using `np.take_along_axis` for fractional peak finding, pre-indexing focus sampling grids, and fast-pathing interior patch extraction. Added synthetic focal stack reconstruction benchmark test in `tests/test_extended_depth_of_focus.py`.

---
*PR created automatically by Jules for task [2797912869011393580](https://jules.google.com/task/2797912869011393580) started by @eigenP*